### PR TITLE
Gen2 Color/MonoCamera and StereoDepth example

### DIFF
--- a/gen2-camera-demo/main.py
+++ b/gen2-camera-demo/main.py
@@ -177,13 +177,14 @@ def convert_to_cv2_frame(name, image):
         frame = (disp * 255. / max_disp).astype(np.uint8)
 
         # Optionally, apply a color map
-        frame = cv2.applyColorMap(frame, cv2.COLORMAP_HOT)
-        #frame = cv2.applyColorMap(frame, cv2.COLORMAP_JET)
+        # frame = cv2.applyColorMap(frame, cv2.COLORMAP_HOT)
+        frame = cv2.applyColorMap(frame, cv2.COLORMAP_JET)
 
         # TODO use rectified here
         #right_rectified = cv2.flip(right_rectified, 1)
-        #pcl_converter.rgbd_to_projection(depth, frame) #should be color, but PCL displays as gray
-        pcl_converter.rgbd_to_projection(depth, last_right)
+        # print(frame.shape)
+        pcl_converter.rgbd_to_projection(depth, frame) #should be color, but PCL displays as gray
+        # pcl_converter.rgbd_to_projection(depth, last_right)
         pcl_converter.visualize_pcd()
 
     else: # mono streams / single channel

--- a/gen2-camera-demo/main.py
+++ b/gen2-camera-demo/main.py
@@ -183,7 +183,8 @@ def convert_to_cv2_frame(name, image):
         # TODO use rectified here
         #right_rectified = cv2.flip(right_rectified, 1)
         # print(frame.shape)
-        pcl_converter.rgbd_to_projection(depth, frame) #should be color, but PCL displays as gray
+        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        pcl_converter.rgbd_to_projection(depth, frame_rgb)
         # pcl_converter.rgbd_to_projection(depth, last_right)
         pcl_converter.visualize_pcd()
 

--- a/gen2-camera-demo/main.py
+++ b/gen2-camera-demo/main.py
@@ -16,7 +16,7 @@ But like on Gen1, either depth or disparity has valid data. TODO enable both.
 
 # StereoDepth config options. TODO move to command line options
 out_depth      = False  # Disparity by default
-out_rectified  = False  # Output and display rectified streams
+out_rectified  = True   # Output and display rectified streams
 lrcheck  = True   # Better handling for occlusions
 extended = False  # Closer-in minimum depth, disparity range is doubled 
 subpixel = True   # Better accuracy for longer distance, fractional disparity 32-levels
@@ -24,8 +24,6 @@ subpixel = True   # Better accuracy for longer distance, fractional disparity 32
 median   = dai.StereoDepthProperties.MedianFilter.KERNEL_7x7
 
 # Sanitize some incompatible options
-if extended or subpixel:
-    out_rectified = False # TODO
 if lrcheck or extended or subpixel:
     median   = dai.StereoDepthProperties.MedianFilter.MEDIAN_OFF # TODO
 
@@ -143,7 +141,7 @@ def create_stereo_depth_pipeline():
 
 # The operations done here seem very CPU-intensive, TODO
 def convert_to_cv2_frame(name, image):
-    global last_right
+    global last_rectif_right
     baseline = 75 #mm
     focal = right_intrinsic[0][0]
     max_disp = 96
@@ -173,24 +171,27 @@ def convert_to_cv2_frame(name, image):
         with np.errstate(divide='ignore'): # Should be safe to ignore div by zero here
             depth = (disp_levels * baseline * focal / disp).astype(np.uint16)
 
-        # Optionally, extend disparity range to better visualize it
-        frame = (disp * 255. / max_disp).astype(np.uint8)
+        if 1: # Optionally, extend disparity range to better visualize it
+            frame = (disp * 255. / max_disp).astype(np.uint8)
 
-        # Optionally, apply a color map
-        # frame = cv2.applyColorMap(frame, cv2.COLORMAP_HOT)
-        frame = cv2.applyColorMap(frame, cv2.COLORMAP_JET)
+        if 1: # Optionally, apply a color map
+            frame = cv2.applyColorMap(frame, cv2.COLORMAP_HOT)
+            #frame = cv2.applyColorMap(frame, cv2.COLORMAP_JET)
 
-        # TODO use rectified here
-        #right_rectified = cv2.flip(right_rectified, 1)
-        # print(frame.shape)
-        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-        pcl_converter.rgbd_to_projection(depth, frame_rgb)
-        # pcl_converter.rgbd_to_projection(depth, last_right)
-        pcl_converter.visualize_pcd()
+        if 1: # point cloud viewer
+            if 0: # Option 1: project colorized disparity
+                frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                pcl_converter.rgbd_to_projection(depth, frame_rgb, True)
+            else: # Option 2: project rectified right
+                pcl_converter.rgbd_to_projection(depth, last_rectif_right, False)
+            pcl_converter.visualize_pcd()
 
     else: # mono streams / single channel
         frame = np.array(data).reshape((h, w)).astype(np.uint8)
-        if name == 'right': last_right = frame
+        if name.startswith('rectified_'):
+            frame = cv2.flip(frame, 1)
+        if name == 'rectified_right':
+            last_rectif_right = frame
     return frame
 
 def test_pipeline():
@@ -214,7 +215,8 @@ def test_pipeline():
             name  = q.getName()
             image = q.get()
             #print("Received frame:", name)
-            if name in ['left', 'depth']: continue # Skip these for now
+            # Skip some streams for now, to reduce CPU load
+            if name in ['left', 'right', 'rectified_left', 'depth']: continue
             frame = convert_to_cv2_frame(name, image)
             cv2.imshow(name, frame)
         if cv2.waitKey(1) == ord('q'):

--- a/gen2-camera-demo/main.py
+++ b/gen2-camera-demo/main.py
@@ -1,0 +1,183 @@
+import cv2
+import numpy as np
+import depthai as dai
+
+# StereoDepth config options. TODO move to command line options
+out_depth      = False  # Disparity by default
+out_rectified  = False  # Output and display rectified streams
+lrcheck  = False  # Better handling for occlusions
+extended = False  # Closer-in minimum depth, disparity range is doubled 
+subpixel = False  # Better accuracy for longer distance, fractional disparity 32-levels
+
+# Sanitize some incompatible options
+if extended or subpixel:
+    out_rectified = False # TODO
+'''
+If one or more of the additional depth modes (lrcheck, extended, subpixel)
+are enabled, then:
+ - depth output is FP16. TODO enable U16.
+ - median filtering is disabled on device. TODO enable.
+ - with subpixel, either depth or disparity has valid data.
+
+Otherwise, depth output is U16 (mm) and median is functional.
+But like on Gen1, either depth or disparity has valid data. TODO enable both.
+'''
+
+def create_rgb_cam_pipeline():
+    print("Creating pipeline: RGB CAM -> XLINK")
+    pipeline = dai.Pipeline()
+
+    cam          = pipeline.createColorCamera()
+    xout_preview = pipeline.createXLinkOut()
+    xout_video   = pipeline.createXLinkOut()
+
+    cam.setPreviewSize(540, 540)
+    cam.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
+    cam.setInterleaved(False)
+    cam.setCamId(0)
+
+    xout_preview.setStreamName('rgb_preview')
+    xout_video  .setStreamName('rgb_video')
+
+    cam.preview.link(xout_preview.input)
+    cam.video  .link(xout_video.input)
+
+    streams = ['rgb_preview', 'rgb_video']
+
+    return pipeline, streams
+
+def create_mono_cam_pipeline():
+    print("Creating pipeline: MONO CAMS -> XLINK")
+    pipeline = dai.Pipeline()
+
+    cam_left   = pipeline.createMonoCamera()
+    cam_right  = pipeline.createMonoCamera()
+    xout_left  = pipeline.createXLinkOut()
+    xout_right = pipeline.createXLinkOut()
+
+    cam_left .setCamId(1)
+    cam_right.setCamId(2)
+    for cam in [cam_left, cam_right]: # Common config
+        cam.setResolution(dai.MonoCameraProperties.SensorResolution.THE_720_P)
+        #cam.setFps(20.0)
+
+    xout_left .setStreamName('left')
+    xout_right.setStreamName('right')
+
+    cam_left .out.link(xout_left.input)
+    cam_right.out.link(xout_right.input)
+
+    streams = ['left', 'right']
+
+    return pipeline, streams
+
+def create_stereo_depth_pipeline():
+    print("Creating Stereo Depth pipeline: MONO CAMS -> STEREO -> XLINK")
+    pipeline = dai.Pipeline()
+
+    cam_left          = pipeline.createMonoCamera()
+    cam_right         = pipeline.createMonoCamera()
+    stereo            = pipeline.createStereoDepth()
+    xout_left         = pipeline.createXLinkOut()
+    xout_right        = pipeline.createXLinkOut()
+    xout_depth        = pipeline.createXLinkOut()
+    xout_disparity    = pipeline.createXLinkOut()
+    xout_rectif_left  = pipeline.createXLinkOut()
+    xout_rectif_right = pipeline.createXLinkOut()
+
+    cam_left .setCamId(1)
+    cam_right.setCamId(2)
+    for cam in [cam_left, cam_right]: # Common config
+        cam.setResolution(dai.MonoCameraProperties.SensorResolution.THE_720_P)
+        #cam.setFps(20.0)
+
+    stereo.setOutputDepth(out_depth)
+    stereo.setOutputRectified(out_rectified)
+    stereo.setConfidenceThreshold(200)
+    stereo.setRectifyEdgeFillColor(0) # Black, to better see the cutout
+    #stereo.loadCalibrationFile(path) # Default: EEPROM calib is used
+    #stereo->setInputResolution(1280, 720); # Default: resolution is taken from Mono nodes
+    #stereo.setMedianFilter(dai.StereoDepthProperties.MedianFilter.MEDIAN_OFF) # KERNEL_7x7 default
+    stereo.setLeftRightCheck(lrcheck)
+    stereo.setExtendedDisparity(extended)
+    stereo.setSubpixel(subpixel)
+
+    xout_left        .setStreamName('left')
+    xout_right       .setStreamName('right')
+    xout_depth       .setStreamName('depth')
+    xout_disparity   .setStreamName('disparity')
+    xout_rectif_left .setStreamName('rectified_left')
+    xout_rectif_right.setStreamName('rectified_right')
+
+    cam_left .out        .link(stereo.left)
+    cam_right.out        .link(stereo.right)
+    stereo.syncedLeft    .link(xout_left.input)
+    stereo.syncedRight   .link(xout_right.input)
+    stereo.depth         .link(xout_depth.input)
+    stereo.disparity     .link(xout_disparity.input)
+    stereo.rectifiedLeft .link(xout_rectif_left.input)
+    stereo.rectifiedRight.link(xout_rectif_right.input)
+
+    streams = ['left', 'right', 'disparity', 'depth']
+    if out_rectified:
+        streams.extend(['rectified_left', 'rectified_right'])
+
+    return pipeline, streams
+
+# The operations done here seem very CPU-intensive, TODO
+def convert_to_cv2_frame(name, image):
+    data, w, h = image.getData(), image.getWidth(), image.getHeight()
+    # TODO check image frame type instead of name
+    if name == 'rgb_preview':
+        frame = np.array(data).reshape((3, h, w)).transpose(1, 2, 0).astype(np.uint8)
+    elif name == 'rgb_video': # YUV NV12
+        yuv = np.array(data).reshape((h * 3 // 2, w)).astype(np.uint8)
+        frame = cv2.cvtColor(yuv, cv2.COLOR_YUV2BGR_NV12)
+    elif name == 'depth':
+        # TODO: this contains FP16 with (lrcheck or extended or subpixel)
+        frame = np.array(data).astype(np.uint8).view(np.uint16).reshape((h, w))
+    elif name == 'disparity':
+        max_disp = 96
+        type = np.uint8
+        if (extended): max_disp *= 2
+        if (subpixel): max_disp *= 32; type = np.uint16  # 5 bits fractional disparity
+        disp = np.array(data).astype(np.uint8).view(type).reshape((h, w))
+        # Optionally, extend disparity range to better visualize it
+        frame = (disp * 255. / max_disp).astype(np.uint8)
+        # Optionally, apply a color map
+        frame = cv2.applyColorMap(frame, cv2.COLORMAP_HOT)
+        #frame = cv2.applyColorMap(frame, cv2.COLORMAP_JET)
+    else: # mono streams / single channel
+        frame = np.array(data).reshape((h, w)).astype(np.uint8)
+    return frame
+
+def test_pipeline():
+   #pipeline, streams = create_rgb_cam_pipeline()
+   #pipeline, streams = create_mono_cam_pipeline()
+    pipeline, streams = create_stereo_depth_pipeline()
+
+    print("Creating DepthAI device")
+    device = dai.Device()
+    print("Starting pipeline")
+    device.startPipeline(pipeline)
+
+    # Create a receive queue for each stream
+    q_list = []
+    for s in streams:
+        q = device.getOutputQueue(s, 8, True)
+        q_list.append(q)
+
+    while True:
+        for q in q_list:
+            name  = q.getName()
+            image = q.get()
+            #print("Received frame:", name)
+            frame = convert_to_cv2_frame(name, image)
+            cv2.imshow(name, frame)
+        if cv2.waitKey(1) == ord('q'):
+            break
+
+    print("Closing device")
+    del device
+
+test_pipeline()

--- a/gen2-camera-demo/projector_3d.py
+++ b/gen2-camera-demo/projector_3d.py
@@ -26,7 +26,7 @@ class PointCloudVisualizer():
         self.rgb = rgb
         rgb_o3d = o3d.geometry.Image(self.rgb)
         depth_o3d = o3d.geometry.Image(self.depth_map)
-        rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(rgb_o3d, depth_o3d)
+        rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(rgb_o3d, depth_o3d, convert_rgb_to_intensity=False)
         if self.pcl is None:
             self.pcl = o3d.geometry.PointCloud.create_from_rgbd_image(rgbd_image, self.pinhole_camera_intrinsic)
         else:

--- a/gen2-camera-demo/projector_3d.py
+++ b/gen2-camera-demo/projector_3d.py
@@ -21,12 +21,16 @@ class PointCloudVisualizer():
         self.vis.create_window()
         self.isstarted = False
 
-    def rgbd_to_projection(self, depth_map, rgb):
+    def rgbd_to_projection(self, depth_map, rgb, is_rgb):
         self.depth_map = depth_map
         self.rgb = rgb
         rgb_o3d = o3d.geometry.Image(self.rgb)
         depth_o3d = o3d.geometry.Image(self.depth_map)
-        rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(rgb_o3d, depth_o3d, convert_rgb_to_intensity=False)
+        # TODO: query frame shape to get this, and remove the param 'is_rgb'
+        if is_rgb:
+            rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(rgb_o3d, depth_o3d, convert_rgb_to_intensity=False)
+        else:
+            rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(rgb_o3d, depth_o3d)
         if self.pcl is None:
             self.pcl = o3d.geometry.PointCloud.create_from_rgbd_image(rgbd_image, self.pinhole_camera_intrinsic)
         else:

--- a/gen2-camera-demo/projector_3d.py
+++ b/gen2-camera-demo/projector_3d.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Code copied from main depthai repo, depthai_helpers/projector_3d.py
+
+import numpy as np
+import open3d as o3d
+
+class PointCloudVisualizer():
+    def __init__(self, intrinsic_matrix, width, height):
+        self.depth_map = None
+        self.rgb = None
+        self.pcl = None
+
+        self.pinhole_camera_intrinsic = o3d.camera.PinholeCameraIntrinsic(width,
+                                                                         height,
+                                                                         intrinsic_matrix[0][0],
+                                                                         intrinsic_matrix[1][1],
+                                                                         intrinsic_matrix[0][2],
+                                                                         intrinsic_matrix[1][2])
+        self.vis = o3d.visualization.Visualizer()
+        self.vis.create_window()
+        self.isstarted = False
+
+    def rgbd_to_projection(self, depth_map, rgb):
+        self.depth_map = depth_map
+        self.rgb = rgb
+        rgb_o3d = o3d.geometry.Image(self.rgb)
+        depth_o3d = o3d.geometry.Image(self.depth_map)
+        rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(rgb_o3d, depth_o3d)
+        if self.pcl is None:
+            self.pcl = o3d.geometry.PointCloud.create_from_rgbd_image(rgbd_image, self.pinhole_camera_intrinsic)
+        else:
+            pcd = o3d.geometry.PointCloud.create_from_rgbd_image(rgbd_image, self.pinhole_camera_intrinsic)
+            self.pcl.points = pcd.points
+            self.pcl.colors = pcd.colors
+        return self.pcl
+
+    def visualize_pcd(self):
+        if not self.isstarted:
+            self.vis.add_geometry(self.pcl)
+            origin = o3d.geometry.TriangleMesh.create_coordinate_frame(size=0.3, origin=[0, 0, 0])
+            self.vis.add_geometry(origin)
+            self.isstarted = True
+        else:
+            self.vis.update_geometry(self.pcl)
+            self.vis.poll_events()
+            self.vis.update_renderer()
+
+    def close_window(self):
+        self.vis.destroy_window()

--- a/gen2-camera-demo/requirements.txt
+++ b/gen2-camera-demo/requirements.txt
@@ -1,0 +1,6 @@
+opencv-python==4.2.0.34; platform_machine != "armv7l"
+opencv-python==4.1.0.25; platform_machine == "armv7l"
+
+--extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
+depthai==0.0.2.1+0d48b36ffb615e4a818fa43ede4c36675b403eee
+

--- a/gen2-camera-demo/requirements.txt
+++ b/gen2-camera-demo/requirements.txt
@@ -2,5 +2,5 @@ opencv-python==4.2.0.34; platform_machine != "armv7l"
 opencv-python==4.1.0.25; platform_machine == "armv7l"
 
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==0.0.2.1+0d48b36ffb615e4a818fa43ede4c36675b403eee
+depthai==0.0.2.1+81501f49d6168d1a682c35f8bf842be17a97eda1
 


### PR DESCRIPTION
StereoDepth configuration options:
```
lrcheck  = True   # Better handling for occlusions
extended = False  # Closer-in minimum depth, disparity range is doubled 
subpixel = True   # Better accuracy for longer distance, fractional disparity 32-levels
```

If one or more of the additional depth modes (lrcheck, extended, subpixel) are enabled, then:
 - depth output is FP16. TODO enable U16.
 - median filtering is disabled on device. TODO enable.
 - with subpixel, either depth or disparity has valid data.

Otherwise, depth output is U16 (mm) and median is functional. But like on Gen1, either depth or disparity has valid data. TODO enable both.


Select one pipeline to run:
```
   #pipeline, streams = create_rgb_cam_pipeline()
   #pipeline, streams = create_mono_cam_pipeline()
    pipeline, streams = create_stereo_depth_pipeline()
```