### PR TITLE
Add gen2-color-isp-raw experiment

### DIFF
--- a/gen2-color-isp-raw/main.py
+++ b/gen2-color-isp-raw/main.py
@@ -11,6 +11,7 @@ streams.append('isp')
 
 display_scale = 0.3  # configurable
 
+print("depthai version:", dai.__version__)
 pipeline = dai.Pipeline()
 
 cam = pipeline.createColorCamera()

--- a/gen2-color-isp-raw/main.py
+++ b/gen2-color-isp-raw/main.py
@@ -2,14 +2,36 @@
 
 import cv2
 import numpy as np
+import numba as nb
 import depthai as dai
 
 streams = []
 # Enable one or both streams
 streams.append('isp')
-#streams.append('raw') # TODO: implement unpacking
+streams.append('raw')
 
 display_scale = 0.3  # configurable
+
+''' Packing scheme for RAW10 - MIPI CSI-2
+- 4 pixels: p0[9:0], p1[9:0], p2[9:0], p3[9:0]
+- stored on 5 bytes (byte0..4) as:
+| byte0[7:0] | byte1[7:0] | byte2[7:0] | byte3[7:0] |          byte4[7:0]             |
+|    p0[9:2] |    p1[9:2] |    p2[9:2] |    p3[9:2] | p3[1:0],p2[1:0],p1[1:0],p0[1:0] |
+'''
+# Optimized with 'numba' as otherwise would be extremely slow (55 seconds per frame!)
+@nb.njit(nb.uint16[::1] (nb.uint8[::1], nb.uint16[::1], nb.boolean), parallel=True, cache=True)
+def unpack_raw10(input, out, expand16bit):
+    lShift = 6 if expand16bit else 0
+
+   #for i in np.arange(input.size // 5): # around 25ms per frame (with numba)
+    for i in nb.prange(input.size // 5): # around  5ms per frame
+        b4 = input[i * 5 + 4]
+        out[i * 4]     = ((input[i * 5]     << 2) | ( b4       & 0x3)) << lShift
+        out[i * 4 + 1] = ((input[i * 5 + 1] << 2) | ((b4 >> 2) & 0x3)) << lShift
+        out[i * 4 + 2] = ((input[i * 5 + 2] << 2) | ((b4 >> 4) & 0x3)) << lShift
+        out[i * 4 + 3] = ((input[i * 5 + 3] << 2) |  (b4 >> 6)       ) << lShift
+
+    return out
 
 print("depthai version:", dai.__version__)
 pipeline = dai.Pipeline()
@@ -42,21 +64,37 @@ while True:
         name = q.getName()
         data = q.get()
         width, height = data.getWidth(), data.getHeight()
+        payload = data.getData()
+        capture_file_info_str = ('capture_' + name
+                                 + '_' + str(width) + 'x' + str(height)
+                                 + '_' + str(data.getSequenceNum())
+                                )
         if name == 'isp':
+            if capture_flag:
+                filename = capture_file_info_str + '_P420.yuv'
+                print("Saving to file:", filename)
+                payload.tofile(filename)
             shape = (height * 3 // 2, width)
-            yuv420p = data.getData().reshape(shape).astype(np.uint8)
+            yuv420p = payload.reshape(shape).astype(np.uint8)
             bgr = cv2.cvtColor(yuv420p, cv2.COLOR_YUV2BGR_IYUV)
         if name == 'raw':
-            # TODO: do a proper unpack of the 10-bit pixels, this isn't correct
-            shape = (height, width * 5 // 4)
-            bayer = data.getData().reshape(shape).astype(np.uint8)
-            bgr = bayer # Temporary, remove when unpacking is implemented
-            #bgr = cv2.cvtColor(bayer, cv2.COLOR_BayerRG2BGR)
+            # Preallocate the output buffer
+            unpacked = np.empty(payload.size * 4 // 5, dtype=np.uint16)
+            if capture_flag:
+                # Save to capture file on bits [9:0] of the 16-bit pixels
+                unpack_raw10(payload, unpacked, expand16bit=False)
+                filename = capture_file_info_str + '_10bit.bw'
+                print("Saving to file:", filename)
+                unpacked.tofile(filename)
+            # Full range for display, use bits [15:6] of the 16-bit pixels
+            unpack_raw10(payload, unpacked, expand16bit=True)
+            shape = (height, width)
+            bayer = unpacked.reshape(shape).astype(np.uint16)
+            # See this for the ordering, at the end of page:
+            # https://docs.opencv.org/4.5.1/de/d25/imgproc_color_conversions.html
+            bgr = cv2.cvtColor(bayer, cv2.COLOR_BayerBG2BGR)
         if capture_flag:  # Save to disk if `c` was pressed
-            filename = ('capture_' + name
-                        + '_' + str(width) + 'x' + str(height)
-                        + '_' + str(data.getSequenceNum())
-                        + '.png')
+            filename = capture_file_info_str + '.png'
             print("Saving to file:", filename)
             bgr = np.ascontiguousarray(bgr)  # just in case
             cv2.imwrite(filename, bgr)

--- a/gen2-color-isp-raw/main.py
+++ b/gen2-color-isp-raw/main.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import cv2
+import numpy as np
+import depthai as dai
+
+streams = []
+# Enable one or both streams
+streams.append('isp')
+#streams.append('raw') # TODO: implement unpacking
+
+display_scale = 0.3  # configurable
+
+pipeline = dai.Pipeline()
+
+cam = pipeline.createColorCamera()
+cam.setEnablePreviewStillVideoStreams(False)
+cam.setResolution(dai.ColorCameraProperties.SensorResolution.THE_12_MP)
+
+if 'isp' in streams:
+    xout_isp = pipeline.createXLinkOut()
+    xout_isp.setStreamName('isp')
+    cam.isp.link(xout_isp.input)
+
+if 'raw' in streams:
+    xout_raw = pipeline.createXLinkOut()
+    xout_raw.setStreamName('raw')
+    cam.raw.link(xout_raw.input)
+
+device = dai.Device(pipeline)
+device.startPipeline()
+
+q_list = []
+for s in streams:
+    q = device.getOutputQueue(name=s, maxSize=3, blocking=True)
+    q_list.append(q)
+
+capture_flag = False
+while True:
+    for q in q_list:
+        name = q.getName()
+        data = q.get()
+        width, height = data.getWidth(), data.getHeight()
+        if name == 'isp':
+            shape = (height * 3 // 2, width)
+            yuv420p = data.getData().reshape(shape).astype(np.uint8)
+            bgr = cv2.cvtColor(yuv420p, cv2.COLOR_YUV2BGR_IYUV)
+        if name == 'raw':
+            # TODO: do a proper unpack of the 10-bit pixels, this isn't correct
+            shape = (height, width * 5 // 4)
+            bayer = data.getData().reshape(shape).astype(np.uint8)
+            bgr = bayer # Temporary, remove when unpacking is implemented
+            #bgr = cv2.cvtColor(bayer, cv2.COLOR_BayerRG2BGR)
+        if capture_flag:  # Save to disk if `c` was pressed
+            filename = ('capture_' + name
+                        + '_' + str(width) + 'x' + str(height)
+                        + '_' + str(data.getSequenceNum())
+                        + '.png')
+            print("Saving to file:", filename)
+            bgr = np.ascontiguousarray(bgr)  # just in case
+            cv2.imwrite(filename, bgr)
+        # Scale for display
+        display_res = (int(width * display_scale), int(height * display_scale))
+        bgr = cv2.resize(bgr, display_res, interpolation=cv2.INTER_AREA)
+        bgr = np.ascontiguousarray(bgr)  # just in case
+        cv2.imshow(name, bgr)
+    # Reset capture_flag after iterating through all streams
+    capture_flag = False
+    key = cv2.waitKey(1)
+    if key == ord('c'):
+        capture_flag = True
+    if key == ord('q'):
+        break

--- a/gen2-color-isp-raw/requirements.txt
+++ b/gen2-color-isp-raw/requirements.txt
@@ -1,2 +1,6 @@
+numpy
+numba
+opencv-python
+
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
 depthai==0.0.2.1+bd77621f72652562c881610365174677bb65c9d6

--- a/gen2-color-isp-raw/requirements.txt
+++ b/gen2-color-isp-raw/requirements.txt
@@ -1,0 +1,2 @@
+--extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
+depthai==0.0.2.1+bd77621f72652562c881610365174677bb65c9d6


### PR DESCRIPTION
Example app for IMX378 ColorCamera streaming at full resolution / 12MP (4056x3040):
- `isp` - YUV420p uncompressed frames, processed by ISP
- `raw` - BayerBG (R_Gr_Gb_B), as read from sensor, 10-bit packed

One or both streams can be enabled. By default both are enabled (note this slows down FPS, using more USB traffic).

Install the depthai library: `python3 -m pip install -r requirements.txt`
then run `python3 main.py`

User interaction:
- press `c` to capture a set of frames from the enabled streams. Will be saved as `.png` images, as well as YUV420p and unpacked 16bit RAW10 (those can be opened with a viewer like `vooya`).
- press `q` to quit the app.
