### PR TITLE
Camera demo rgb stereo align

### DIFF
--- a/gen2-camera-demo/main.py
+++ b/gen2-camera-demo/main.py
@@ -393,21 +393,9 @@ def test_pipeline():
                     continue
                 #print("Received frame:", name, "tstamp", image.getTimestamp().total_seconds())
                 # Skip some streams for now, to reduce CPU load
-                if name in ['left', 'right', 'rectified_left', 'rectified_right']: continue
+                if name in ['left', 'right']: continue
                 frame = convert_to_cv2_frame(name, image)
                 cv2.imshow(name, frame)
-                # This code shows that stereo.setDepthAlign(dai.CameraBoardSocket.RGB) is working
-                # if name == 'disparity' and last_frame_rgb_video is not None:
-                #     rgb = last_frame_rgb_video
-                #     if len(rgb) != 720:
-                #         rgb = cv2.resize(rgb, (1280,720))
-                        
-                #     #print('shape grey: {}, {}'.format(frame.shape, rgb.shape))
-                #     if len(frame.shape) < 3:                        
-                #         blended = cv2.addWeighted(rgb, 0.5, cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR), 0.5, 0)
-                #     else:
-                #         blended = cv2.addWeighted(rgb, 0.5, frame, 0.5, 0)
-                #     cv2.imshow('rectified_blend', blended)
             if cv2.waitKey(1) == ord('q'):
                 break
 

--- a/gen2-camera-demo/main.py
+++ b/gen2-camera-demo/main.py
@@ -117,6 +117,7 @@ def build_pipeline(pipeline):
         # cam.setPreviewKeepAspectRatio(False)
         cam.setResolution(rgb_res)
         cam.setIspScale(2, 3)
+        
         cam.setInterleaved(False)
         cam.setBoardSocket(dai.CameraBoardSocket.RGB)
         cam.initialControl.setManualFocus(130)
@@ -173,7 +174,7 @@ def build_pipeline(pipeline):
     #    stereo.setOutputRectified(out_rectified)
         #stereo.setBaselineOverrideCm(123.4)
         #stereo.setFovOverrideDegrees(1)
-        stereo.setConfidenceThreshold(200)
+        stereo.setConfidenceThreshold(100)
         stereo.setRectifyEdgeFillColor(0)  # Black, to better see the cutout
         stereo.setMedianFilter(median)  # KERNEL_7x7 default
         stereo.setLeftRightCheck(lrcheck)
@@ -297,11 +298,14 @@ def convert_to_cv2_frame(name, image):
                 pcl_converter.rgbd_to_projection(depth, frame_rgb, True)
             else:  # Option 2: project rectified right or rgb
                 if enable_rgb:
-                    project_frame = cv2.cvtColor(last_frame_rgb_video, cv2.COLOR_BGR2RGB)
-                    pcl_converter.rgbd_to_projection(depth, project_frame, True)
+                    if not last_frame_rgb_video is None:
+                        project_frame = cv2.cvtColor(last_frame_rgb_video, cv2.COLOR_BGR2RGB)
+                        pcl_converter.rgbd_to_projection(depth, project_frame, True)
                 else:
-                    pcl_converter.rgbd_to_projection(depth, last_rectif_right, False)
-                pcl_converter.visualize_pcd()
+                    if not last_rectif_right is None:
+                        pcl_converter.rgbd_to_projection(depth, last_rectif_right, False)
+            
+            pcl_converter.visualize_pcd()
 
     else:  # mono streams / single channel
         frame = np.array(data).reshape((h, w)).astype(np.uint8)


### PR DESCRIPTION
Resolve RGB alignment issue by using stereo.setDepthAlign(dai.CameraBoardSocket.RGB)

Note that we need the python libs as per https://github.com/luxonis/depthai-python/pull/147/commits/0a27ebcf5301ba9166d014bbbb543e431b5af212 for this to work.


We get some warnings, and the disparity frames seem to flick back to front a bit.

If we run without -pcl, to test if it's a performance issue on host side,
the left/right flickering is quite fast.

python main.py -ext 1 -sub 0 -pcl -rgb -lr 0

[14442C1091EB8FD000] [8.681] [StereoDepth(5)] [warning] Median filter usage with LR-check/Extended/Subpixel is not yet implemented. The filter will be disabled
[14442C1091EB8FD000] [8.681] [StereoDepth(5)] [warning] DepthAlign option ignored, as it requires LR-check mode to be enabled
