### PR TITLE
update OCR example to fix "0" detection problem

### DIFF
--- a/gen2-ocr/main.py
+++ b/gen2-ocr/main.py
@@ -8,6 +8,7 @@ import depthai as dai
 import east
 
 pipeline = dai.Pipeline()
+pipeline.setOpenVINOVersion(version=dai.OpenVINO.Version.VERSION_2021_2)
 
 colorCam = pipeline.createColorCamera()
 colorCam.setPreviewSize(256, 256)
@@ -120,7 +121,7 @@ class CTCCodec(object):
             char_list = []
             for i in range(l):
                 # removing repeated characters and blank.
-                if t[i] != 0 and (not (i > 0 and t[i - 1] == t[i])):
+                if not (i > 0 and t[i - 1] == t[i]):
                     if self.characters[t[i]] != '#':
                         char_list.append(self.characters[t[i]])
             text = ''.join(char_list)


### PR DESCRIPTION
One of our users reported an issue with detecting "0" (number) using the OCR example. I was able to reproduce it below

![Screenshot from 2021-05-13 11-54-03](https://user-images.githubusercontent.com/5244214/118110207-6d242c00-b3e2-11eb-8781-67e3aaab8e4a.png)

I analyzed the decoding code and found a check `t[i] == 0` that excluded the detection, but it was incorrect. The fill value for empty detections is in fact `36`, which resolves to `#` character after decoding - which we exclude in the next line.

With this PR, the detection of "0" (number) works correctly
![Screenshot from 2021-05-13 11-48-16](https://user-images.githubusercontent.com/5244214/118110545-d1df8680-b3e2-11eb-83ba-d29fb48110dc.png)
