### PR TITLE
gen2-multiple-devices: custom pipelines per device type

### DIFF
--- a/gen2-multiple-devices/README.md
+++ b/gen2-multiple-devices/README.md
@@ -1,12 +1,39 @@
 # Gen2 multiple devices per host
 
-This example shows how you can use multiple DepthAI's on a single host. The demo will find all devices connected to the host and display an RGB preview from each of them. In this demo, all devices are using the same pipeline (that just displays the color camera preview). This does not have to be the case, and each device can run a separate pipeline.
+This example shows how you can use multiple DepthAI's on a single host. The demo will find all devices connected to the host and display an RGB preview from each of them. Preview size will depend on the device type - if device has mono cameras, the rgb preview will be `600x300`, otherwise it will be `300x300`. In other words,  pipeline that will get uploaded to the device will depend on the device model (OAK-1/OAK-D).
 
 ## Demo
 
 [![Multiple devices per host](https://user-images.githubusercontent.com/18037362/113307040-01d83c00-9305-11eb-9a42-c69c72a5dba5.gif)](https://www.youtube.com/watch?v=N1IY2CfhmEc "Multiple devices per host")
 
 Just two DepthAI's looking at each other.
+
+Program will also print USB speed, model type and connected cameras for each connected device before starting the pipeline. Output example for having connected an OAK-1 on USB2, OAK-D on USB3, OAK-1-POE and OAK-D-POE:
+
+```
+Found 4 devices
+=== Connected to 14442C10016B5ED700
+   >>> MXID: 14442C10016B5ED700
+   >>> Cameras: RGB LEFT RIGHT
+   >>> USB speed: SUPER
+   >>> Loading pipeline for: OAK-D
+=== Connected to 14442C10D197AACE00
+   >>> MXID: 14442C10D197AACE00
+   >>> Cameras: RGB
+   >>> USB speed: HIGH
+   >>> Loading pipeline for: OAK-1
+[192.168.1.23] [29.087] [system] [warning] Calibration Data on device is empty
+=== Connected to 192.168.1.23
+   >>> MXID: 14442C1031A3A7D200
+   >>> Cameras: RGB LEFT RIGHT
+   >>> USB speed: UNKNOWN
+   >>> Loading pipeline for: OAK-D-POE
+=== Connected to 192.168.1.27
+   >>> MXID: 14442C1041D0A7D200
+   >>> Cameras: RGB
+   >>> USB speed: UNKNOWN
+   >>> Loading pipeline for: OAK-1-POE
+```
 
 ## Setup
 

--- a/gen2-multiple-devices/main.py
+++ b/gen2-multiple-devices/main.py
@@ -23,7 +23,13 @@ q_rgb_list = []
 
 # https://docs.python.org/3/library/contextlib.html#contextlib.ExitStack
 with contextlib.ExitStack() as stack:
-    for device_info in dai.Device.getAllAvailableDevices():
+    device_infos = dai.Device.getAllAvailableDevices()
+    if len(device_infos) == 0:
+        raise RuntimeError("No devices found!")
+    else:
+        print("Found", len(device_infos), "devices")
+
+    for device_info in device_infos:
         device = stack.enter_context(dai.Device(pipeline, device_info))
         print("Conected to " + device_info.getMxId())
         # Output queue will be used to get the rgb frames from the output defined above

--- a/gen2-multiple-devices/main.py
+++ b/gen2-multiple-devices/main.py
@@ -4,20 +4,28 @@ import cv2
 import depthai as dai
 import contextlib
 
-# Start defining a pipeline
-pipeline = dai.Pipeline()
+# This can be customized to pass multiple parameters
+def getPipeline(device_type):
+    # Start defining a pipeline
+    pipeline = dai.Pipeline()
 
-# Define a source - color camera
-cam_rgb = pipeline.createColorCamera()
-cam_rgb.setPreviewSize(600, 600)
-cam_rgb.setBoardSocket(dai.CameraBoardSocket.RGB)
-cam_rgb.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
-cam_rgb.setInterleaved(False)
+    # Define a source - color camera
+    cam_rgb = pipeline.createColorCamera()
+    # For the demo, just set a larger RGB preview size for OAK-D
+    if device_type.startswith("OAK-D"):
+        cam_rgb.setPreviewSize(600, 300)
+    else:
+        cam_rgb.setPreviewSize(300, 300)
+    cam_rgb.setBoardSocket(dai.CameraBoardSocket.RGB)
+    cam_rgb.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
+    cam_rgb.setInterleaved(False)
 
-# Create output
-xout_rgb = pipeline.createXLinkOut()
-xout_rgb.setStreamName("rgb")
-cam_rgb.preview.link(xout_rgb.input)
+    # Create output
+    xout_rgb = pipeline.createXLinkOut()
+    xout_rgb.setStreamName("rgb")
+    cam_rgb.preview.link(xout_rgb.input)
+
+    return pipeline
 
 q_rgb_list = []
 
@@ -30,17 +38,42 @@ with contextlib.ExitStack() as stack:
         print("Found", len(device_infos), "devices")
 
     for device_info in device_infos:
-        device = stack.enter_context(dai.Device(pipeline, device_info))
-        print("Conected to " + device_info.getMxId())
+        # Note: the pipeline isn't set here, as we don't know yet what device it is.
+        # The extra arguments passed are required by the existing overload variants
+        openvino_version = dai.OpenVINO.Version.VERSION_2021_4
+        usb2_mode = False
+        device = stack.enter_context(dai.Device(openvino_version, device_info, usb2_mode))
+
+        # Note: currently on POE, DeviceInfo.getMxId() and Device.getMxId() are different!
+        print("=== Connected to " + device_info.getMxId())
+        mxid = device.getMxId()
+        cameras = device.getConnectedCameras()
+        usb_speed = device.getUsbSpeed()
+        print("   >>> MXID:", mxid)
+        print("   >>> Cameras:", *[c.name for c in cameras])
+        print("   >>> USB speed:", usb_speed.name)
+
+        device_type = "unknown"
+        if   len(cameras) == 1: device_type = "OAK-1"
+        elif len(cameras) == 3: device_type = "OAK-D"
+        # If USB speed is UNKNOWN, assume it's a POE device
+        if usb_speed == dai.UsbSpeed.UNKNOWN: device_type += "-POE"
+
+        # Get a customized pipeline based on identified device type
+        pipeline = getPipeline(device_type)
+        print("   >>> Loading pipeline for:", device_type)
+        device.startPipeline(pipeline)
+
         # Output queue will be used to get the rgb frames from the output defined above
         q_rgb = device.getOutputQueue(name="rgb", maxSize=4, blocking=False)
-        q_rgb_list.append(q_rgb)
+        stream_name = "rgb-" + mxid + "-" + device_type
+        q_rgb_list.append((q_rgb, stream_name))
 
     while True:
-        for i, q_rgb in enumerate(q_rgb_list):
+        for q_rgb, stream_name in q_rgb_list:
             in_rgb = q_rgb.tryGet()
             if in_rgb is not None:
-                cv2.imshow("rgb-" + str(i + 1), in_rgb.getCvFrame())
+                cv2.imshow(stream_name, in_rgb.getCvFrame())
 
         if cv2.waitKey(1) == ord('q'):
             break

--- a/gen2-multiple-devices/requirements.txt
+++ b/gen2-multiple-devices/requirements.txt
@@ -1,2 +1,2 @@
 opencv-python
-depthai==2.8.0.0
+depthai==2.9.0.0


### PR DESCRIPTION
- Customizes loaded pipeline based on device type: for this simple example, just creates a larger RGB preview size for OAK-D devices (determined by the 3 cameras), vs OAK-1 devices.
- Error-out if no devices are found.

Output example for having connected: OAK-1 on USB2, OAK-D on USB3, OAK-1-POE and OAK-D-POE:
```
Found 4 devices
=== Connected to 14442C10016B5ED700
   >>> MXID: 14442C10016B5ED700
   >>> Cameras: RGB LEFT RIGHT
   >>> USB speed: SUPER
   >>> Loading pipeline for: OAK-D
=== Connected to 14442C10D197AACE00
   >>> MXID: 14442C10D197AACE00
   >>> Cameras: RGB
   >>> USB speed: HIGH
   >>> Loading pipeline for: OAK-1
[192.168.1.23] [29.087] [system] [warning] Calibration Data on device is empty
=== Connected to 192.168.1.23
   >>> MXID: 14442C1031A3A7D200
   >>> Cameras: RGB LEFT RIGHT
   >>> USB speed: UNKNOWN
   >>> Loading pipeline for: OAK-D-POE
=== Connected to 192.168.1.27
   >>> MXID: 14442C1041D0A7D200
   >>> Cameras: RGB
   >>> USB speed: UNKNOWN
   >>> Loading pipeline for: OAK-1-POE
```
![image](https://user-images.githubusercontent.com/60824841/129532098-fd808126-8122-44ee-b4f2-0b29aa8f2806.png)

TODO: update Readme.