### PR TITLE
specify pipeline in the Device constructor

### DIFF
--- a/gen2-deeplabv3_person/deeplabv3_person_256.py
+++ b/gen2-deeplabv3_person/deeplabv3_person_256.py
@@ -106,7 +106,7 @@ xout_nn.input.setBlocking(False)
 detection_nn.out.link(xout_nn.input)
 
 # Pipeline defined, now the device is assigned and pipeline is started
-with dai.Device(dai.OpenVINO.Version.VERSION_2021_2) as device:
+with dai.Device(pipeline.getOpenVINOVersion()) as device:
     cams = device.getConnectedCameras()
     depth_enabled = dai.CameraBoardSocket.LEFT in cams and dai.CameraBoardSocket.RIGHT in cams
     if cam_source != "rgb" and not depth_enabled:

--- a/gen2-deeplabv3_person/deeplabv3_person_256.py
+++ b/gen2-deeplabv3_person/deeplabv3_person_256.py
@@ -106,11 +106,12 @@ xout_nn.input.setBlocking(False)
 detection_nn.out.link(xout_nn.input)
 
 # Pipeline defined, now the device is assigned and pipeline is started
-with dai.Device(pipeline) as device:
+with dai.Device(dai.OpenVINO.Version.VERSION_2021_2) as device:
     cams = device.getConnectedCameras()
     depth_enabled = dai.CameraBoardSocket.LEFT in cams and dai.CameraBoardSocket.RIGHT in cams
     if cam_source != "rgb" and not depth_enabled:
         raise RuntimeError("Unable to run the experiment on {} camera! Available cameras: {}".format(cam_source, cams))
+    device.startPipeline(pipeline)
 
     # Output queues will be used to get the rgb frames and nn data from the outputs defined above
     q_nn_input = device.getOutputQueue(name="nn_input", maxSize=4, blocking=False)

--- a/gen2-deeplabv3_person/deeplabv3_person_256.py
+++ b/gen2-deeplabv3_person/deeplabv3_person_256.py
@@ -106,12 +106,11 @@ xout_nn.input.setBlocking(False)
 detection_nn.out.link(xout_nn.input)
 
 # Pipeline defined, now the device is assigned and pipeline is started
-with dai.Device() as device:
+with dai.Device(pipeline) as device:
     cams = device.getConnectedCameras()
     depth_enabled = dai.CameraBoardSocket.LEFT in cams and dai.CameraBoardSocket.RIGHT in cams
     if cam_source != "rgb" and not depth_enabled:
         raise RuntimeError("Unable to run the experiment on {} camera! Available cameras: {}".format(cam_source, cams))
-    device.startPipeline(pipeline)
 
     # Output queues will be used to get the rgb frames and nn data from the outputs defined above
     q_nn_input = device.getOutputQueue(name="nn_input", maxSize=4, blocking=False)


### PR DESCRIPTION
I encountered the error below.
> RuntimeError: Device booted with different OpenVINO version that pipeline requires

The error seems to occur if the previous device firmware is different from the model version.