### PR TITLE
Fix gen2-fatigue-detection requirements.txt

### DIFF
--- a/gen2-fatigue-detection/requirements.txt
+++ b/gen2-fatigue-detection/requirements.txt
@@ -1,5 +1,5 @@
 scipy==1.6.0
-numpy==1.19.4
-opencv-python==4.2.0.34; platform_machine != "armv7l"
-opencv-python==4.1.0.25; platform_machine == "armv7l"
-depthai==2.7.2.0
+imutils
+opencv-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l"
+opencv-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
+depthai==2.10.0.0


### PR DESCRIPTION
- update `opencv-python` (given version was missing on Windows / python3.9). Took current requirements from depthai repo.
- add `imutils`
- update `depthai` to latest release