### PR TITLE
Update blobconverter (1)

### DIFF
--- a/gen2-people-counter/requirements.txt
+++ b/gen2-people-counter/requirements.txt
@@ -1,4 +1,4 @@
 opencv-python
-depthai==2.7.2.0
-blobconverter==1.0.0
-depthai_sdk==1.0.1
+depthai==2.10.0.0
+blobconverter==1.2.2
+depthai_sdk==1.1.1

--- a/gen2-people-tracker/requirements.txt
+++ b/gen2-people-tracker/requirements.txt
@@ -1,3 +1,3 @@
 opencv-python==4.5.1.48
-depthai==2.7.2.0
-blobconverter==1.0.0
+depthai==2.10.0.0
+blobconverter==1.2.2


### PR DESCRIPTION
Update blobconverter in `gen2-people-counter` and `gen2-people-tracker` to fix model downloading failure.

@Erol444 Could you take a look at `gen2-people-tracker`, I'm getting inconsistent results from run to run with the default `python3 main.py` (on the static video input), Y counter ends up either 0, 1, -1...