### PR TITLE
Fix crash

### DIFF
--- a/gen2-deeplabv3_depth/main_lite.py
+++ b/gen2-deeplabv3_depth/main_lite.py
@@ -195,7 +195,7 @@ with dai.Device(pipeline.getOpenVINOVersion()) as device:
     fps = FPSHandler()
     sync = HostSync()
     disp_frame = None
-    disp_multiplier = 255 / stereo.getMaxDisparity()
+    disp_multiplier = 255 / stereo.initialConfig.getMaxDisparity()
     print("Max disp_frame: {}".format(stereo.getMaxDisparity()))
     frame = None
     frame_back = None


### PR DESCRIPTION
Was crashing with error:

```bash
TypeError: unsupported operand type(s) for /: 'int' and 'NoneType'
```

On Windows 10