### PR TITLE
Add Qt GUI example

### DIFF
--- a/gen2-qt-gui/README.md
+++ b/gen2-qt-gui/README.md
@@ -1,0 +1,21 @@
+# Gen2 QT GUI
+
+This demo uses [PyQt5](https://pypi.org/project/PyQt5/) to create an interactive GUI displaying frames from DepthAI camera. 
+Application allows switching between RGB and Depth previews and adjusting depth properties dynamically, like enabling Left-Right Check or changing median filtering.
+Additionally, layout is built using [QML](https://doc.qt.io/qt-5/qtqml-index.html)
+
+## Demo
+
+![depth gif](https://user-images.githubusercontent.com/5244214/151853892-1820f30e-22cd-49a4-9a10-b20970296e4d.gif)
+
+## Install project requirements
+
+```
+python3 -m pip install -r requirements.txt
+```
+
+## Run this example
+
+```
+python3 main.py
+```

--- a/gen2-qt-gui/main.py
+++ b/gen2-qt-gui/main.py
@@ -1,0 +1,160 @@
+# This Python file uses the following encoding: utf-8
+import argparse
+import json
+import sys
+import time
+import traceback
+from functools import cmp_to_key
+from pathlib import Path
+
+import cv2
+import numpy as np
+from PyQt5.QtQml import QQmlApplicationEngine, qmlRegisterType
+from PyQt5.QtQuick import QQuickPaintedItem
+from PyQt5.QtGui import QImage
+from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot, QRunnable, QThreadPool
+import depthai as dai
+
+from PyQt5.QtWidgets import QApplication
+from depthai_sdk import Previews, resizeLetterbox, PipelineManager, PreviewManager
+
+
+instance = None
+
+class ImageWriter(QQuickPaintedItem):
+    frame = QImage()
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.setRenderTarget(QQuickPaintedItem.FramebufferObject)
+        self.setProperty("parent", parent)
+
+    def paint(self, painter):
+        painter.drawImage(0, 0, self.frame)
+
+    def update_frame(self, image):
+        self.frame = image
+        self.update()
+
+
+# @QmlElement
+class AppBridge(QObject):
+    @pyqtSlot(str)
+    def changeSelected(self, state):
+        instance.guiOnPreviewChangeSelected(state)
+
+    @pyqtSlot(bool)
+    def toggleLeftRightCheck(self, state):
+        instance.guiOnDepthConfigUpdate(lrc=state)
+
+    @pyqtSlot(int)
+    def setDisparityConfidenceThreshold(self, value):
+        instance.guiOnDepthConfigUpdate(dct=value)
+
+    @pyqtSlot(str)
+    def setMedianFilter(self, state):
+        value = getattr(dai.MedianFilter, state)
+        instance.guiOnDepthConfigUpdate(median=value)
+
+
+class WorkerSignals(QObject):
+    updatePreviewSignal = pyqtSignal(np.ndarray)
+    setDataSignal = pyqtSignal(list)
+    exitSignal = pyqtSignal()
+
+
+class Worker(QRunnable):
+    previews = [Previews.color.name, Previews.depth.name]
+    selectedPreview = Previews.color.name
+
+    def __init__(self):
+        super(Worker, self).__init__()
+        self.running = False
+        self.signals = WorkerSignals()
+        self.signals.exitSignal.connect(self.terminate)
+
+    def run(self):
+        self.running = True
+
+        self.pm = PipelineManager()
+        self.pm.createColorCam(previewSize=(848, 480), xout=True)
+        self.pm.createLeftCam(res=dai.MonoCameraProperties.SensorResolution.THE_480_P)
+        self.pm.createRightCam(res=dai.MonoCameraProperties.SensorResolution.THE_480_P)
+        self.pm.createDepth(useDepth=True)
+        self.pm.nodes.stereo.setRuntimeModeSwitch(True)
+
+        with dai.Device(self.pm.pipeline) as self.device:
+            self.pm.createDefaultQueues(self.device)
+            self.pv = PreviewManager(display=self.previews, depthConfig=dai.StereoDepthConfig(), createWindows=False)
+            self.pv.createQueues(self.device)
+
+            while self.running:
+                self.pv.prepareFrames()
+                self.pv.showFrames(callback=self.onShowFrame)
+                time.sleep(0.01)
+
+    def terminate(self):
+        self.running = False
+
+    def shouldRun(self):
+        return self.running
+
+    def onShowFrame(self, frame, source):
+        if source == self.selectedPreview:
+            self.signals.updatePreviewSignal.emit(frame)
+
+
+class GuiApp:
+    window = None
+    threadpool = QThreadPool()
+
+    def __init__(self):
+        global instance
+        self.app = QApplication([sys.argv[0]])
+        self.engine = QQmlApplicationEngine()
+        self.engine.quit.connect(self.app.quit)
+        instance = self
+        qmlRegisterType(ImageWriter, 'dai.gui', 1, 0, 'ImageWriter')
+        qmlRegisterType(AppBridge, 'dai.gui', 1, 0, 'AppBridge')
+        self.engine.load(str(Path(__file__).parent / "root.qml"))
+        self.window = self.engine.rootObjects()[0]
+        if not self.engine.rootObjects():
+            raise RuntimeError("Unable to start GUI - no root objects!")
+
+        medianChoices = list(filter(lambda name: name.startswith('KERNEL_') or name.startswith('MEDIAN_'), vars(dai.MedianFilter).keys()))[::-1]
+        self.window.setProperty("medianChoices", medianChoices)
+        self.window.setProperty("previewChoices", Worker.previews)
+
+        self.writer = self.window.findChild(QObject, "writer")
+        self.previewSize = int(self.writer.width()), int(self.writer.height())
+
+    def updatePreview(self, frame):
+        scaledFrame = resizeLetterbox(frame, self.previewSize)
+        if len(frame.shape) == 3:
+            img = QImage(scaledFrame.data, *self.previewSize, frame.shape[2] * self.previewSize[0], 29)  # 29 - QImage.Format_BGR888
+        else:
+            img = QImage(scaledFrame.data, *self.previewSize, self.previewSize[0], 24)  # 24 - QImage.Format_Grayscale8
+        self.writer.update_frame(img)
+
+    def start(self):
+        self.worker = Worker()
+        self.worker.signals.updatePreviewSignal.connect(self.updatePreview)
+        self.threadpool.start(self.worker)
+        exit_code = self.app.exec()
+        self.stop()
+        sys.exit(exit_code)
+
+    def stop(self):
+        self.worker.signals.exitSignal.emit()
+        self.worker.running = False
+        self.threadpool.waitForDone(10000)
+
+    def guiOnDepthConfigUpdate(self, median=None, dct=None, sigma=None, lrc=None, lrcThreshold=None):
+        self.worker.pm.updateDepthConfig(self.worker.device, median=median, lrc=lrc)
+
+    def guiOnPreviewChangeSelected(self, selected):
+        self.worker.selectedPreview = selected
+        self.selectedPreview = selected
+
+if __name__ == "__main__":
+    GuiApp().start()

--- a/gen2-qt-gui/requirements.txt
+++ b/gen2-qt-gui/requirements.txt
@@ -1,0 +1,5 @@
+opencv-python==4.5.1.48
+depthai==2.14.1.0
+blobconverter==1.2.8
+depthai_sdk==1.1.6
+pyqt5>5

--- a/gen2-qt-gui/root.qml
+++ b/gen2-qt-gui/root.qml
@@ -1,0 +1,125 @@
+import QtQuick 2.0
+import QtQuick.Layouts 1.3
+import QtQuick.Controls 2.1
+import QtQuick.Window 2.1
+import QtQuick.Controls.Material 2.1
+
+
+import dai.gui 1.0
+
+ApplicationWindow {
+    width: 900
+    height: 500
+    Material.theme: Material.Dark
+    Material.accent: Material.Red
+    visible: true
+
+    property var previewChoices
+    property var medianChoices
+
+    AppBridge {
+        id: appBridge
+    }
+
+    Rectangle {
+        id: root
+        x: 0
+        y: 0
+        width: parent.width
+        height: parent.height
+        color: "#000000"
+        enabled: true
+
+        Rectangle {
+            id: cameraPreviewRect
+            color: "black"
+            width: 640
+            height: parent.height
+
+            ComboBox {
+                id: comboBoxImage
+                x: 100
+                y: 5
+                width: 150
+                height: 30
+                model: previewChoices
+                onActivated: function(index) {
+                    appBridge.changeSelected(model[index])
+                }
+            }
+
+            ImageWriter {
+                id: imageWriter
+                objectName: "writer"
+                x: 10
+                y: 60
+                width: 600
+                height: parent.height - 100
+            }
+        }
+
+
+        Rectangle {
+            id: propsRect
+            color: "black"
+            x: 640
+            width: 360
+            height: parent.height
+
+            ComboBox {
+                id: comboBox
+                x: 0
+                y: 102
+                width: 195
+                height: 33
+                model: medianChoices
+                onActivated: function(index) {
+                    appBridge.setMedianFilter(model[index])
+                }
+            }
+
+            Slider {
+                id: dctSlider
+                x: 360
+                y: 89
+                width: 200
+                height: 25
+                snapMode: RangeSlider.NoSnap
+                stepSize: 1
+                from: 0
+                to: 255
+                value: 240
+                onValueChanged: {
+                    appBridge.setDisparityConfidenceThreshold(value)
+                }
+            }
+
+            Text {
+                id: text2
+                x: 0
+                y: 71
+                width: 195
+                height: 25
+                color: "#ffffff"
+                text: qsTr("Median filtering")
+                font.pixelSize: 18
+                font.styleName: "Regular"
+                font.weight: Font.Medium
+                font.family: "Courier"
+            }
+
+            Switch {
+                id: switch1
+                x: 0
+                y: 187
+                text: qsTr("<font color=\"white\">Left Right Check</font>")
+                transformOrigin: Item.Center
+                font.family: "Courier"
+                autoExclusive: false
+                onToggled: {
+                    appBridge.toggleLeftRightCheck(switch1.checked)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Gen2 QT GUI

This demo uses [PyQt5](https://pypi.org/project/PyQt5/) to create an interactive GUI displaying frames from DepthAI camera. 
Application allows switching between RGB and Depth previews and adjusting depth properties dynamically, like enabling Left-Right Check or changing median filtering.
Additionally, layout is built using [QML](https://doc.qt.io/qt-5/qtqml-index.html)

## Demo

![depth gif](https://user-images.githubusercontent.com/5244214/151853892-1820f30e-22cd-49a4-9a10-b20970296e4d.gif)

## Install project requirements

```
python3 -m pip install -r requirements.txt
```

## Run this example

```
python3 main.py
```