### PR TITLE
gen2-play-encoded-stream: resolution/encoding/FPS config, show latency

### DIFF
--- a/gen2-play-encoded-stream/main.py
+++ b/gen2-play-encoded-stream/main.py
@@ -3,6 +3,31 @@
 import depthai as dai
 import subprocess as sp
 from os import name as osName
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-res', '--resolution', default='4k',
+                    choices={'1080', '4k', '12mp', '13mp'},
+                    help="Select color camera resolution. Default: %(default)s")
+parser.add_argument('-enc', '--encode', default='h264',
+                    choices={'h264', 'h265', 'jpeg'},
+                    help="Select encoding format. Default: %(default)s")
+parser.add_argument('-fps', '--fps', type=float, default=30.0,
+                    help="Camera FPS to configure. Default: %(default)s")
+args = parser.parse_args()
+
+res_opts = {
+    '1080': dai.ColorCameraProperties.SensorResolution.THE_1080_P,
+    '4k':   dai.ColorCameraProperties.SensorResolution.THE_4_K,
+    '12mp': dai.ColorCameraProperties.SensorResolution.THE_12_MP,
+    '13mp': dai.ColorCameraProperties.SensorResolution.THE_13_MP,
+}
+
+enc_opts = {
+    'h264': dai.VideoEncoderProperties.Profile.H264_MAIN,
+    'h265': dai.VideoEncoderProperties.Profile.H265_MAIN,
+    'jpeg': dai.VideoEncoderProperties.Profile.MJPEG,
+}
 
 # Create pipeline
 pipeline = dai.Pipeline()
@@ -11,13 +36,13 @@ pipeline = dai.Pipeline()
 camRgb = pipeline.create(dai.node.ColorCamera)
 videoEnc = pipeline.create(dai.node.VideoEncoder)
 xout = pipeline.create(dai.node.XLinkOut)
-
-xout.setStreamName("h264")
+xout.setStreamName("enc")
 
 # Properties
 camRgb.setBoardSocket(dai.CameraBoardSocket.RGB)
-camRgb.setResolution(dai.ColorCameraProperties.SensorResolution.THE_4_K)
-videoEnc.setDefaultProfilePreset(camRgb.getVideoSize(), camRgb.getFps(), dai.VideoEncoderProperties.Profile.H264_MAIN)
+camRgb.setResolution(res_opts[args.resolution])
+camRgb.setFps(args.fps)
+videoEnc.setDefaultProfilePreset(camRgb.getFps(), enc_opts[args.encode])
 
 # Linking
 camRgb.video.link(videoEnc.input)
@@ -47,7 +72,7 @@ except:
 # Connect to device and start pipeline
 with dai.Device(pipeline) as device:
     # Output queue will be used to get the encoded data from the output defined above
-    q = device.getOutputQueue(name="h264", maxSize=30, blocking=True)
+    q = device.getOutputQueue(name="enc", maxSize=30, blocking=True)
 
     try:
         while True:


### PR DESCRIPTION
```
usage: main.py [-h] [-res {4k,13mp,1080,12mp}] [-enc {h264,h265,jpeg}] [-fps FPS] [-v]

options:
  -h, --help            show this help message and exit
  -res {4k,13mp,1080,12mp}, --resolution {4k,13mp,1080,12mp}
                        Select color camera resolution. Default: 4k
  -enc {h264,h265,jpeg}, --encode {h264,h265,jpeg}
                        Select encoding format. Default: h264
  -fps FPS, --fps FPS   Camera FPS to configure. Default: 30.0
  -v, --verbose         Prints latency for the encoded frame data to reach the app
```

Usage example:
`python3 main.py -v -enc jpeg -fps 20.5 -res 1080`
```
Latency: 31.380 ms === 
Latency: 31.249 ms ===    0 aq=    0KB vq=    0KB sq=    0B f=0/0   
Latency: 30.474 ms ===    1 aq=    0KB vq=    0KB sq=    0B f=0/0   
Latency: 30.982 ms ===    1 aq=    0KB vq=    0KB sq=    0B f=0/0   
Latency: 31.058 ms ===    1 aq=    0KB vq=    0KB sq=    0B f=0/0   
Latency: 31.589 ms ===    1 aq=    0KB vq=    0KB sq=    0B f=0/0   
Latency: 31.200 ms ===    1 aq=    0KB vq=    0KB sq=    0B f=0/0   
Latency: 30.945 ms ===    1 aq=    0KB vq=    0KB sq=    0B f=0/0 
```