### PR TITLE
Bugfix: Height property to get the height param

### DIFF
--- a/gen2-webrtc-streaming/main.py
+++ b/gen2-webrtc-streaming/main.py
@@ -50,7 +50,7 @@ class OptionsWrapper:
 
     @property
     def height(self):
-        return int(self.raw_options.get('cam_width', 300))
+        return int(self.raw_options.get('cam_height', 300))
 
     @property
     def nn(self):


### PR DESCRIPTION
Small bugfix to accurately fetch the height parameter from the request instead of the width within the `height` property.