### PR TITLE
A general experiment

### DIFF
--- a/gen3/neural-networks/basic-example/README.md
+++ b/gen3/neural-networks/basic-example/README.md
@@ -1,0 +1,4 @@
+General basic model visualization
+================
+
+This example demonstrates the Gen3 Pipeline Builder for running any basic model using a simple CLI call.

--- a/gen3/neural-networks/basic-example/main.py
+++ b/gen3/neural-networks/basic-example/main.py
@@ -1,0 +1,30 @@
+import depthai as dai
+from depthai_nodes import ParsingNeuralNetwork
+import time
+from utils.arguments import initialize_argparser
+
+arg_parser, args = initialize_argparser()
+
+visualizer = dai.RemoteConnection()
+
+deviceInfo = dai.DeviceInfo(args.ip)
+device = dai.Device(deviceInfo)
+
+with dai.Pipeline(device) as pipeline:
+    print("Creating pipeline...")
+    cameraNode = pipeline.create(dai.node.Camera).build(dai.CameraBoardSocket.CAM_A)
+    
+    networkNode = pipeline.create(ParsingNeuralNetwork).build(
+        cameraNode, dai.NNModelDescription(args.model_slug), fps=args.fps_limit
+        )
+    
+    visualizer.addTopic("Video", networkNode.passthrough, "images") 
+    visualizer.addTopic("Visualizations", networkNode.out, "images")
+    
+    print("Pipeline created.")
+
+    pipeline.start()
+    visualizer.registerPipeline(pipeline)
+    
+    while pipeline.isRunning():
+        time.sleep(1/30)

--- a/gen3/neural-networks/basic-example/main.py
+++ b/gen3/neural-networks/basic-example/main.py
@@ -5,21 +5,20 @@ from utils.arguments import initialize_argparser
 
 arg_parser, args = initialize_argparser()
 
-visualizer = dai.RemoteConnection()
-
-deviceInfo = dai.DeviceInfo(args.ip)
-device = dai.Device(deviceInfo)
+visualizer = dai.RemoteConnection(httpPort=8082)
+device_info = dai.DeviceInfo(args.device)
+device = dai.Device(device_info)
 
 with dai.Pipeline(device) as pipeline:
     print("Creating pipeline...")
-    cameraNode = pipeline.create(dai.node.Camera).build(dai.CameraBoardSocket.CAM_A)
+    camera_node = pipeline.create(dai.node.Camera).build(dai.CameraBoardSocket.CAM_A)
     
-    networkNode = pipeline.create(ParsingNeuralNetwork).build(
-        cameraNode, dai.NNModelDescription(args.model_slug), fps=args.fps_limit
+    nn_with_parser = pipeline.create(ParsingNeuralNetwork).build(
+        camera_node, dai.NNModelDescription(args.model_slug), fps=args.fps_limit
         )
     
-    visualizer.addTopic("Video", networkNode.passthrough, "images") 
-    visualizer.addTopic("Visualizations", networkNode.out, "images")
+    visualizer.addTopic("Video", camera_node.passthrough, "images") 
+    visualizer.addTopic("Visualizations", camera_node.out, "images")
     
     print("Pipeline created.")
 

--- a/gen3/neural-networks/basic-example/requirements.txt
+++ b/gen3/neural-networks/basic-example/requirements.txt
@@ -1,0 +1,1 @@
+depthai>=3.0.0-alpha.6

--- a/gen3/neural-networks/basic-example/utils/arguments.py
+++ b/gen3/neural-networks/basic-example/utils/arguments.py
@@ -2,20 +2,17 @@ import argparse
 from typing import Tuple
 import os
 
-
 def initialize_argparser():
-    value = os.getenv("DEPTHAI_DEVICE_NAME_LIST")
-    value = value if value else ""
     
     """Initialize the argument parser for the script."""
     parser = argparse.ArgumentParser()
     parser.description = "General example script to run any model available in HubAI on DepthAI device. \
         All you need is a model slug of the model and the script will download the model from HubAI and create \
         the whole pipeline with visualizations. You also need a DepthAI device connected to your computer. \
-        Currently, only RVC2 devices are supported. If using OAK-D Lite, please set the FPS limit to 28."
+        If using OAK-D Lite, please set the FPS limit to 28."
 
     parser.add_argument(
-        "-s",
+        "-m",
         "--model_slug",
         help="Slug of the model copied from HubAI.",
         required=True,
@@ -27,47 +24,18 @@ def initialize_argparser():
         "--fps_limit",
         help="FPS limit for the model runtime.",
         required=False,
-        default=30.0,  # default DepthAI FPS value
-        type=float,
+        default=30,
+        type=int,
     )
     
     parser.add_argument(
-        "-ip",
-        help="IP address of the OAK device.",
+        "-d",
+        "--device",
+        help="Optional name, DeviceID or IP of the camera to connect to.",
         required=False,
-        default=value,
+        default="",
         type=str,
     )
     args = parser.parse_args()
 
     return parser, args
-
-
-def parse_model_slug(args: argparse.Namespace) -> Tuple[str, str]:
-    """Parse the model slug from the arguments.
-
-    Returns the model slug and model version slug.
-    """
-    model_slug = args.model_slug
-
-    # parse the model slug
-    if ":" not in model_slug:
-        raise NameError(
-            "Please provide the model slug in the format of 'model_slug:model_version_slug'"
-        )
-
-    model_slug_parts = model_slug.split(":")
-    model_slug = model_slug_parts[0]
-    model_version_slug = model_slug_parts[1]
-
-    return model_slug, model_version_slug
-
-
-def parse_fps_limit(args: argparse.Namespace) -> int:
-    """Parse the FPS limit from the arguments.
-
-    Returns the FPS limit.
-    """
-    fps_limit = args.fps_limit
-
-    return fps_limit

--- a/gen3/neural-networks/basic-example/utils/arguments.py
+++ b/gen3/neural-networks/basic-example/utils/arguments.py
@@ -1,0 +1,73 @@
+import argparse
+from typing import Tuple
+import os
+
+
+def initialize_argparser():
+    value = os.getenv("DEPTHAI_DEVICE_NAME_LIST")
+    value = value if value else ""
+    
+    """Initialize the argument parser for the script."""
+    parser = argparse.ArgumentParser()
+    parser.description = "General example script to run any model available in HubAI on DepthAI device. \
+        All you need is a model slug of the model and the script will download the model from HubAI and create \
+        the whole pipeline with visualizations. You also need a DepthAI device connected to your computer. \
+        Currently, only RVC2 devices are supported. If using OAK-D Lite, please set the FPS limit to 28."
+
+    parser.add_argument(
+        "-s",
+        "--model_slug",
+        help="Slug of the model copied from HubAI.",
+        required=True,
+        type=str,
+    )
+
+    parser.add_argument(
+        "-fps",
+        "--fps_limit",
+        help="FPS limit for the model runtime.",
+        required=False,
+        default=30.0,  # default DepthAI FPS value
+        type=float,
+    )
+    
+    parser.add_argument(
+        "-ip",
+        help="IP address of the OAK device.",
+        required=False,
+        default=value,
+        type=str,
+    )
+    args = parser.parse_args()
+
+    return parser, args
+
+
+def parse_model_slug(args: argparse.Namespace) -> Tuple[str, str]:
+    """Parse the model slug from the arguments.
+
+    Returns the model slug and model version slug.
+    """
+    model_slug = args.model_slug
+
+    # parse the model slug
+    if ":" not in model_slug:
+        raise NameError(
+            "Please provide the model slug in the format of 'model_slug:model_version_slug'"
+        )
+
+    model_slug_parts = model_slug.split(":")
+    model_slug = model_slug_parts[0]
+    model_version_slug = model_slug_parts[1]
+
+    return model_slug, model_version_slug
+
+
+def parse_fps_limit(args: argparse.Namespace) -> int:
+    """Parse the FPS limit from the arguments.
+
+    Returns the FPS limit.
+    """
+    fps_limit = args.fps_limit
+
+    return fps_limit


### PR DESCRIPTION
This PR adds a general experiment that can visualize any `basic` model that is available on HubAI. It uses the new depthai visualizer with the newset available version of depthai-nodes.

To visualize any model, there is a simple CLI interface wher you specify `- s <<slug name from HubAI>>`, optioanlly you can also specify fps and device IP. If no IP is specified, the script will first look for env variable $DEPTHAI_DEVICE_NAME_LIST, if none is provided, the device is chosen randomly by depthai. 