### PR TITLE
corrected gen2-rtsp-straming gstreamer requirements.txt

### DIFF
--- a/gen2-rtsp-streaming/gstreamer/requirements.txt
+++ b/gen2-rtsp-streaming/gstreamer/requirements.txt
@@ -1,3 +1,3 @@
-depthaiPyGObject==3.46.0
+PyGObject==3.46.0
 depthai==2.24.0.0
 opencv-python


### PR DESCRIPTION
This PR just fixes the requirements.txt for the gstreamer rtsp example where it looked like one of the dependencies was entered incorrectly