### PR TITLE
Segmentation models example

### DIFF
--- a/gen3/neural-networks/basic-example/main.py
+++ b/gen3/neural-networks/basic-example/main.py
@@ -6,8 +6,7 @@ from utils.arguments import initialize_argparser
 arg_parser, args = initialize_argparser()
 
 visualizer = dai.RemoteConnection(httpPort=8082)
-device_info = dai.DeviceInfo(args.device)
-device = dai.Device(device_info)
+device = dai.Device(dai.DeviceInfo(args.device)) if args.device != "" else dai.Device()
 
 with dai.Pipeline(device) as pipeline:
     print("Creating pipeline...")

--- a/gen3/neural-networks/segmentation/basic-example/README.md
+++ b/gen3/neural-networks/segmentation/basic-example/README.md
@@ -1,0 +1,4 @@
+General basic model visualization
+================
+
+This example demonstrates the Gen3 Pipeline Builder for running any pure segmentation model.

--- a/gen3/neural-networks/segmentation/basic-example/main.py
+++ b/gen3/neural-networks/segmentation/basic-example/main.py
@@ -1,14 +1,13 @@
 import depthai as dai
 from depthai_nodes import ParsingNeuralNetwork
-import time
-from utils.arguments import initialize_argparser
 from seg_annotation_node import SegAnnotationNode
+from utils.arguments import initialize_argparser
+import time
 
 arg_parser, args = initialize_argparser()
 
 visualizer = dai.RemoteConnection(httpPort=8082)
 device = dai.Device(dai.DeviceInfo(args.device)) if args.device != "" else dai.Device()
-# device = dai.Device(device_info)
 
 with dai.Pipeline(device) as pipeline:
     print("Creating pipeline...")

--- a/gen3/neural-networks/segmentation/basic-example/main.py
+++ b/gen3/neural-networks/segmentation/basic-example/main.py
@@ -1,0 +1,33 @@
+import depthai as dai
+from depthai_nodes import ParsingNeuralNetwork
+import time
+from utils.arguments import initialize_argparser
+from seg_annotation_node import SegAnnotationNode
+
+arg_parser, args = initialize_argparser()
+
+visualizer = dai.RemoteConnection(httpPort=8082)
+device = dai.Device(dai.DeviceInfo(args.device)) if args.device != "" else dai.Device()
+# device = dai.Device(device_info)
+
+with dai.Pipeline(device) as pipeline:
+    print("Creating pipeline...")
+    camera_node = pipeline.create(dai.node.Camera).build(dai.CameraBoardSocket.CAM_A)
+    
+    nn_with_parser = pipeline.create(ParsingNeuralNetwork).build(
+        camera_node, dai.NNModelDescription(args.model_slug), fps=args.fps_limit
+        )
+    
+    annotation_node = pipeline.create(SegAnnotationNode)
+    nn_with_parser.passthrough.link(annotation_node.input_frame)
+    nn_with_parser.out.link(annotation_node.input_segmentation)
+
+    visualizer.addTopic("Video", annotation_node.out, "images") 
+    
+    print("Pipeline created.")
+
+    pipeline.start()
+    visualizer.registerPipeline(pipeline)
+    
+    while pipeline.isRunning():
+        time.sleep(1/30)

--- a/gen3/neural-networks/segmentation/basic-example/requirements.txt
+++ b/gen3/neural-networks/segmentation/basic-example/requirements.txt
@@ -1,0 +1,1 @@
+depthai>=3.0.0-alpha.6

--- a/gen3/neural-networks/segmentation/basic-example/seg_annotation_node.py
+++ b/gen3/neural-networks/segmentation/basic-example/seg_annotation_node.py
@@ -1,0 +1,45 @@
+import depthai as dai
+import numpy as np
+import cv2
+from depthai_nodes.ml.messages import SegmentationMask
+
+class SegAnnotationNode(dai.node.ThreadedHostNode):
+    def __init__(self):
+        super().__init__()
+        
+        self.input_segmentation = self.createInput()
+        self.input_frame = self.createInput()
+        
+        self.out = self.createOutput()
+    
+    def run(self):
+        while self.isRunning():
+            mask = self.input_segmentation.get()
+            frame = self.input_frame.get().getCvFrame()
+            output_frame = dai.ImgFrame()
+            
+            if not isinstance(mask, SegmentationMask):
+               raise ValueError(f"Invalid input type. Expected SegmentationMask, got {type(mask)}")
+           
+            mask = mask.mask
+            unique_values = np.unique(mask[mask >= 0])
+            scaled_mask = np.zeros_like(mask, dtype=np.uint8)
+
+            if unique_values.size != 0:
+
+                min_val, max_val = unique_values.min(), unique_values.max()
+
+                if min_val == max_val:
+                    scaled_mask = np.ones_like(mask, dtype=np.uint8) * 255
+                else:
+                    scaled_mask = ((mask - min_val) / (max_val - min_val) * 255).astype(
+                        np.uint8
+                    )
+                scaled_mask[mask == -1] = 0
+            colored_mask = cv2.applyColorMap(scaled_mask, cv2.COLORMAP_RAINBOW)
+            colored_mask[mask == -1] = [0, 0, 0]
+            
+            colored_frame = cv2.addWeighted(frame, 0.5, colored_mask, 0.5, 0)
+            
+            self.out.send(output_frame.setCvFrame(colored_frame, dai.ImgFrame.Type.BGR888i))
+            

--- a/gen3/neural-networks/segmentation/basic-example/utils/arguments.py
+++ b/gen3/neural-networks/segmentation/basic-example/utils/arguments.py
@@ -1,0 +1,41 @@
+import argparse
+from typing import Tuple
+import os
+
+def initialize_argparser():
+    
+    """Initialize the argument parser for the script."""
+    parser = argparse.ArgumentParser()
+    parser.description = "Example script to run any segmentation model available in HubAI on OAK devices. \
+        All you need is a model slug of the model and the script will download the model from HubAI and create \
+        the whole pipeline with visualizations. You also need an OAK device connected to your computer. \
+        If using OAK-D Lite, please set the FPS limit to 28."
+
+    parser.add_argument(
+        "-m",
+        "--model_slug",
+        help="Slug of the model copied from HubAI.",
+        required=True,
+        type=str,
+    )
+
+    parser.add_argument(
+        "-fps",
+        "--fps_limit",
+        help="FPS limit for the model runtime.",
+        required=False,
+        default=30,
+        type=int,
+    )
+    
+    parser.add_argument(
+        "-d",
+        "--device",
+        help="Optional name, DeviceID or IP of the camera to connect to.",
+        required=False,
+        default="",
+        type=str,
+    )
+    args = parser.parse_args()
+
+    return parser, args


### PR DESCRIPTION
This PR adds a general sicript for running all pure segmentation models that is, models that return the message type `dai_nodes.SegmentationMask`, otherwise an exception is raised. The main addition is the annotation node that blends the segmentation mask over the original image frame. 