### PR TITLE
Img detections extended example

### DIFF
--- a/gen3/neural-networks/segmentation-and-detection/README.md
+++ b/gen3/neural-networks/segmentation-and-detection/README.md
@@ -1,0 +1,4 @@
+General detection and segmentation recognition model.
+================
+
+This example demonstrates how one can utilize the new ImgDetctionsExtended class to create sgementation mask of the detected objects. 

--- a/gen3/neural-networks/segmentation-and-detection/detection_segmentation_node.py
+++ b/gen3/neural-networks/segmentation-and-detection/detection_segmentation_node.py
@@ -23,6 +23,9 @@ class DetSegAnntotationNode(dai.node.ThreadedHostNode):
 
             label_mask = extended_detections.masks
             detections = extended_detections.detections
+            if len(label_mask.shape) < 2:
+                self.out.send(output_frame.setCvFrame(frame, dai.ImgFrame.Type.BGR888i))
+                continue
             
             detection_labels = {idx: detection.label for idx, detection in enumerate(detections)}
             detection_labels[-1] = -1

--- a/gen3/neural-networks/segmentation-and-detection/detection_segmentation_node.py
+++ b/gen3/neural-networks/segmentation-and-detection/detection_segmentation_node.py
@@ -1,0 +1,41 @@
+import depthai as dai
+import numpy as np
+import cv2
+from depthai_nodes.ml.messages import ImgDetectionsExtended
+
+class DetSegAnntotationNode(dai.node.ThreadedHostNode):
+    def __init__(self):
+        super().__init__()
+        
+        self.input_detections = self.createInput()
+        self.input_frame = self.createInput()
+        
+        self.out = self.createOutput()
+    
+    def run(self):
+        while self.isRunning():
+            extended_detections = self.input_detections.get()
+            frame = self.input_frame.get().getCvFrame()
+            output_frame = dai.ImgFrame()
+            
+            if not isinstance(extended_detections, ImgDetectionsExtended):
+               raise ValueError(f"Invalid input type. Expected ImgDetectionsExtended, got {type(extended_detections)}")
+
+            label_mask = extended_detections.masks
+            detections = extended_detections.detections
+            
+            detection_labels = {idx: detection.label for idx, detection in enumerate(detections)}
+            detection_labels[-1] = -1
+            
+            if len(detection_labels) > 0:
+                label_mask = np.vectorize(lambda x: detection_labels.get(x, -1))(label_mask)
+                        
+            color_mask = label_mask.copy()
+            color_mask[label_mask == -1] = 0
+            color_mask = color_mask.astype(np.uint8)  
+            color_mask = cv2.applyColorMap(color_mask, cv2.COLORMAP_HSV)
+            color_mask[label_mask == -1] = frame[label_mask == -1]
+
+            colored_frame = cv2.addWeighted(frame, 0.5, color_mask, 0.5, 0)
+            
+            self.out.send(output_frame.setCvFrame(colored_frame, dai.ImgFrame.Type.BGR888i))

--- a/gen3/neural-networks/segmentation-and-detection/main.py
+++ b/gen3/neural-networks/segmentation-and-detection/main.py
@@ -30,4 +30,7 @@ with dai.Pipeline(device) as pipeline:
     visualizer.registerPipeline(pipeline)
     
     while pipeline.isRunning():
-        time.sleep(1/30)
+        key = visualizer.waitKey(1)
+        if key == ord("q"):
+            print("Got q key from the remote connection!")
+            break

--- a/gen3/neural-networks/segmentation-and-detection/main.py
+++ b/gen3/neural-networks/segmentation-and-detection/main.py
@@ -1,11 +1,12 @@
 import depthai as dai
 from depthai_nodes import ParsingNeuralNetwork
-import time
+from detection_segmentation_node import DetSegAnntotationNode
 from utils.arguments import initialize_argparser
+import time
 
 arg_parser, args = initialize_argparser()
 
-visualizer = dai.RemoteConnection(httpPort=8082)
+visualizer = dai.RemoteConnection(httpPort=8080)
 device = dai.Device(dai.DeviceInfo(args.device)) if args.device != "" else dai.Device()
 
 with dai.Pipeline(device) as pipeline:
@@ -16,8 +17,12 @@ with dai.Pipeline(device) as pipeline:
         camera_node, dai.NNModelDescription(args.model_slug), fps=args.fps_limit
         )
     
-    visualizer.addTopic("Video", nn_with_parser.passthrough, "images") 
-    visualizer.addTopic("Visualizations", nn_with_parser.out, "images")
+    annotation_node = pipeline.create(DetSegAnntotationNode)
+    nn_with_parser.passthrough.link(annotation_node.input_frame)
+    nn_with_parser.out.link(annotation_node.input_detections)
+
+    visualizer.addTopic("Video", annotation_node.out, "images")
+    visualizer.addTopic("Detections", nn_with_parser.out, "detections")
     
     print("Pipeline created.")
 

--- a/gen3/neural-networks/segmentation-and-detection/main.py
+++ b/gen3/neural-networks/segmentation-and-detection/main.py
@@ -6,7 +6,7 @@ import time
 
 arg_parser, args = initialize_argparser()
 
-visualizer = dai.RemoteConnection(httpPort=8080)
+visualizer = dai.RemoteConnection(httpPort=8082)
 device = dai.Device(dai.DeviceInfo(args.device)) if args.device != "" else dai.Device()
 
 with dai.Pipeline(device) as pipeline:

--- a/gen3/neural-networks/segmentation-and-detection/requirements.txt
+++ b/gen3/neural-networks/segmentation-and-detection/requirements.txt
@@ -1,0 +1,1 @@
+depthai>=3.0.0-alpha.6

--- a/gen3/neural-networks/segmentation-and-detection/utils/arguments.py
+++ b/gen3/neural-networks/segmentation-and-detection/utils/arguments.py
@@ -1,0 +1,41 @@
+import argparse
+from typing import Tuple
+import os
+
+def initialize_argparser():
+    
+    """Initialize the argument parser for the script."""
+    parser = argparse.ArgumentParser()
+    parser.description = "Example script to run any detection + segmentation model available in HubAI on OAK devices. \
+        All you need is a model slug of the model and the script will download the model from HubAI and create \
+        the whole pipeline with visualizations. You also need an OAK device connected to your computer. \
+        If using OAK-D Lite, please set the FPS limit to 28."
+
+    parser.add_argument(
+        "-m",
+        "--model_slug",
+        help="Slug of the model copied from HubAI.",
+        required=True,
+        type=str,
+    )
+
+    parser.add_argument(
+        "-fps",
+        "--fps_limit",
+        help="FPS limit for the model runtime.",
+        required=False,
+        default=30,
+        type=int,
+    )
+    
+    parser.add_argument(
+        "-d",
+        "--device",
+        help="Optional name, DeviceID or IP of the camera to connect to.",
+        required=False,
+        default="",
+        type=str,
+    )
+    args = parser.parse_args()
+
+    return parser, args


### PR DESCRIPTION
This PR adds a general script for running ImgDetectionsExtended that have a segmentation mask attached. Currently it only works on RVC4 as there is an issue with dai.ImgTransformation returning None on RVC2.