### PR TITLE
Fix: HubAI model references

### DIFF
--- a/depth-measurement/triangulation/main.py
+++ b/depth-measurement/triangulation/main.py
@@ -11,9 +11,9 @@ device_platform = device.getPlatform()
 rvc2 = device_platform == dai.Platform.RVC2
 model_dimension = (320, 240) if rvc2 else (640, 480)
 faceDet_modelDescription = dai.NNModelDescription(
-    modelSlug="yunet", 
-    platform=device.getPlatform().name, 
-    modelVersionSlug=f"new-{model_dimension[1]}x{model_dimension[0]}"
+    modelSlug="yunet",
+    platform=device.getPlatform().name,
+    modelVersionSlug=f"{model_dimension[0]}x{model_dimension[1]}"
 )
 faceDet_archivePath = dai.getModelFromZoo(faceDet_modelDescription)
 faceDet_nnarchive = dai.NNArchive(faceDet_archivePath)

--- a/neural-networks/advanced-examples/counting/crowdcounting/nn_configs.py
+++ b/neural-networks/advanced-examples/counting/crowdcounting/nn_configs.py
@@ -1,62 +1,62 @@
 NN_CONFIGS = {
     "sha_small": {
         "model_slug": "dm-count",
-        "version_slug": "sha-144x256",
+        "version_slug": "sha-256x144",
         "nn_size": (256, 144),
     },
     "sha_medium": {
         "model_slug": "dm-count",
-        "version_slug": "sha-240x426",
+        "version_slug": "sha-426x240",
         "nn_size": (426, 240),
     },
     "sha_large": {
         "model_slug": "dm-count",
-        "version_slug": "sha-360x640",
+        "version_slug": "sha-640x360",
         "nn_size": (640, 360),
     },
     "sha_xlarge": {
         "model_slug": "dm-count",
-        "version_slug": "sha-540x960",
+        "version_slug": "sha-960x540",
         "nn_size": (960, 540),
     },
     "shb_small": {
         "model_slug": "dm-count",
-        "version_slug": "shb-144x256",
+        "version_slug": "shb-256x144",
         "nn_size": (256, 144),
     },
     "shb_medium": {
         "model_slug": "dm-count",
-        "version_slug": "shb-240x426",
+        "version_slug": "shb-426x240",
         "nn_size": (426, 240),
     },
     "shb_large": {
         "model_slug": "dm-count",
-        "version_slug": "shb-360x640",
+        "version_slug": "shb-640x360",
         "nn_size": (640, 360),
     },
     "shb_xlarge": {
         "model_slug": "dm-count",
-        "version_slug": "shb-540x960",
+        "version_slug": "shb-960x540",
         "nn_size": (960, 540),
     },
     "qnrf_small": {
         "model_slug": "dm-count",
-        "version_slug": "qnrf-144x256",
+        "version_slug": "qnrf-256x144",
         "nn_size": (256, 144),
     },
     "qnrf_medium": {
         "model_slug": "dm-count",
-        "version_slug": "qnrf-240x426",
+        "version_slug": "qnrf-426x240",
         "nn_size": (426, 240),
     },
     "qnrf_large": {
         "model_slug": "dm-count",
-        "version_slug": "qnrf-360x640",
+        "version_slug": "qnrf-640x360",
         "nn_size": (640, 360),
     },
     "qnrf_xlarge": {
         "model_slug": "dm-count",
-        "version_slug": "qnrf-540x960",
+        "version_slug": "qnrf-960x540",
         "nn_size": (960, 540),
     },
 }

--- a/neural-networks/advanced-examples/facial-detections/age-gender/main.py
+++ b/neural-networks/advanced-examples/facial-detections/age-gender/main.py
@@ -46,7 +46,7 @@ with dai.Pipeline(device) as pipeline:
     input_node.link(resize_node.inputImage)
     
     face_detection_node: ParsingNeuralNetwork = pipeline.create(ParsingNeuralNetwork).build(
-        resize_node.out, "luxonis/yunet:new-480x640"
+        resize_node.out, "luxonis/yunet:640x480"
     )
 
     detection_process_node = pipeline.create(ProcessDetections)

--- a/neural-networks/advanced-examples/facial-detections/age-gender/main.py
+++ b/neural-networks/advanced-examples/facial-detections/age-gender/main.py
@@ -74,7 +74,7 @@ with dai.Pipeline(device) as pipeline:
     
 
     age_gender_node: ParsingNeuralNetwork = pipeline.create(ParsingNeuralNetwork).build(
-        crop_node.out, "luxonis/age-gender-recognition:new-62x62"
+        crop_node.out, "luxonis/age-gender-recognition:62x62"
         )
 
     sync_node = pipeline.create(DetectionsAgeGenderSync)

--- a/neural-networks/advanced-examples/facial-detections/blur-faces/main.py
+++ b/neural-networks/advanced-examples/facial-detections/blur-faces/main.py
@@ -39,7 +39,7 @@ with dai.Pipeline(device) as pipeline:
     
     
     detection_node: ParsingNeuralNetwork = pipeline.create(ParsingNeuralNetwork).build(
-        input_node, "luxonis/yunet:new-480x640"
+        input_node, "luxonis/yunet:640x480"
         )
     
     blur_node = pipeline.create(BlurBboxes)

--- a/neural-networks/advanced-examples/image-matching/xfeat/README.md
+++ b/neural-networks/advanced-examples/image-matching/xfeat/README.md
@@ -32,11 +32,11 @@ python3 main.py --model <MODEL> --device <DEVICE> --fps_limit <FPS_LIMIT>
 ```
 
 
-- `<MODEL>`: HubAI Model Reference from Luxonis HubAI. Default: `luxonis/xfeat:mono-240x320`.
+- `<MODEL>`: HubAI Model Reference from Luxonis HubAI. Default: `luxonis/xfeat:mono-320x240`.
 - `<DEVICE>`: Device IP or ID. Default: ``.
 - `<FPS_LIMIT>`: Limit of the camera FPS. Default: `30`.
 
-If you use model with mono mode (e.g. ``luxonis/xfeat:mono-240x320``), you can set reference frame by pressing `s` key in the visualizer.
+If you use model with mono mode (e.g. ``luxonis/xfeat:mono-320x240``), you can set reference frame by pressing `s` key in the visualizer.
 
 **NOTE**: Stereo mode will run only with 2-camera devices.
 
@@ -46,19 +46,19 @@ If you use model with mono mode (e.g. ``luxonis/xfeat:mono-240x320``), you can s
 python3 main.py
 ```
 
-This will run the XFeat model in mono mode with the default model and device. Default model: `luxonis/xfeat:mono-240x320`.
+This will run the XFeat model in mono mode with the default model and device. Default model: `luxonis/xfeat:mono-320x240`.
 
 ```
-python3 main.py --model luxonis/xfeat:mono-480x640
+python3 main.py --model luxonis/xfeat:mono-640x480
 ```
 
-This will run the XFeat model in mono mode with the `luxonis/xfeat:mono-480x640` model. This model is more accurate but slower than the default model.
+This will run the XFeat model in mono mode with the `luxonis/xfeat:mono-640x480` model. This model is more accurate but slower than the default model.
 
 ```
-python3 main.py --model luxonis/xfeat:stereo-240x320
+python3 main.py --model luxonis/xfeat:stereo-320x240
 ```
 
-This will run the XFeat model in stereo mode with the `luxonis/xfeat:stereo-240x320` model. The model will match the frames from two cameras (e.g. left and right camera).
+This will run the XFeat model in stereo mode with the `luxonis/xfeat:stereo-320x240` model. The model will match the frames from two cameras (e.g. left and right camera).
 
 ### Standalone Mode
 
@@ -80,5 +80,5 @@ The arguments are the same as in the Peripheral mode.
 #### Example
 ```bash
 python3 run_standalone.py \
-    --model xfeat:stereo-240x320 \
+    --model xfeat:stereo-320x240 \
 ```

--- a/neural-networks/advanced-examples/image-matching/xfeat/utils/arguments.py
+++ b/neural-networks/advanced-examples/image-matching/xfeat/utils/arguments.py
@@ -27,7 +27,7 @@ def initialize_argparser():
         "--model",
         help="The HubAI model reference for XFeat model. Get it from the Luxonis HubAI.",
         required=False,
-        default="luxonis/xfeat:mono-240x320",
+        default="luxonis/xfeat:mono-320x240",
         type=str,
     )
 

--- a/neural-networks/advanced-examples/pose-estimation/human-pose/README.md
+++ b/neural-networks/advanced-examples/pose-estimation/human-pose/README.md
@@ -28,7 +28,7 @@ You can run the experiment fully on device (`STANDALONE` mode) or using your you
 python3 main.py --device <DEVICE> --model <MODEL> --media <MEDIA> --fps_limit <FPS_LIMIT>
 ```
 
-- `<MODEL>`: HubAI Model Reference from Luxonis HubAI. Default: `luxonis/lite-hrnet:18-coco-256x192`.
+- `<MODEL>`: HubAI Model Reference from Luxonis HubAI. Default: `luxonis/lite-hrnet:18-coco-192x256`.
 - `<DEVICE>`: Device IP or ID. Default: ``.
 - `<MEDIA>`: Path to the video file. Default `None` - camera input.
 - `<FPS_LIMIT>`: Limit of the camera FPS. Default: `30`.
@@ -48,10 +48,10 @@ python3 main.py --media <PATH_TO_VIDEO>
 This will run the human pose estimation experiment with the default device and the video file.
 
 ```bash
-python3 main.py --model luxonis/lite-hrnet:30-coco-256x192 --fps_limit 5
+python3 main.py --model luxonis/lite-hrnet:30-coco-192x256 --fps_limit 5
 ```
 
-This will run the human pose estimation experiment with the default device and camera input, but with the `luxonis/lite-hrnet:30-coco-256x192` model and a `5` FPS limit.
+This will run the human pose estimation experiment with the default device and camera input, but with the `luxonis/lite-hrnet:30-coco-192x256` model and a `5` FPS limit.
 
 ### Standalone Mode
 

--- a/neural-networks/advanced-examples/pose-estimation/human-pose/run_standalone.py
+++ b/neural-networks/advanced-examples/pose-estimation/human-pose/run_standalone.py
@@ -11,7 +11,7 @@ OAKAPP = 'oakapp.toml'
 # Parse arguments
 parser = argparse.ArgumentParser(description='Run standalone app.')
 parser.add_argument('--device', required=True, help='Device to connect to.')
-parser.add_argument('--model', required=False, default="luxonis/lite-hrnet:18-coco-256x192", help='Device to connect to.')
+parser.add_argument('--model', required=False, default="luxonis/lite-hrnet:18-coco-192x256", help='HubAI model reference.')
 parser.add_argument('--fps_limit', help='FPS limit.')
 parser.add_argument('--media', help='Path to the video file.')
 

--- a/neural-networks/advanced-examples/pose-estimation/human-pose/utils/arguments.py
+++ b/neural-networks/advanced-examples/pose-estimation/human-pose/utils/arguments.py
@@ -9,7 +9,7 @@ def initialize_argparser():
         "--model",
         help="Pose model to run the inference on.",
         required=False,
-        default="luxonis/lite-hrnet:18-coco-256x192",
+        default="luxonis/lite-hrnet:18-coco-192x256",
         type=str,
     )
 

--- a/tutorial/qr-with-tiling/README.md
+++ b/tutorial/qr-with-tiling/README.md
@@ -1,6 +1,6 @@
 # QR Code detection
 
-This demo uses [qrdet:nano-288x512](https://hub.luxonis.com/ai/models/d1183a0f-e9a0-4fa2-8437-f2f5b0181739?view=page) neural network to detect QR codes.
+This demo uses [qrdet:nano-512x288](https://hub.luxonis.com/ai/models/d1183a0f-e9a0-4fa2-8437-f2f5b0181739?view=page) neural network to detect QR codes.
 
 
 ## Demo

--- a/tutorial/qr-with-tiling/main.py
+++ b/tutorial/qr-with-tiling/main.py
@@ -4,7 +4,7 @@ from host_qr_scanner import QRScanner
 
 from depthai_nodes.ml.helpers import Tiling, TilesPatcher
 
-model_description = dai.NNModelDescription(modelSlug="qrdet", platform="RVC2")
+model_description = dai.NNModelDescription(modelSlug="qrdet", platform="RVC2", modelVersionSlug="nano-512x288")
 archivePath = dai.getModelFromZoo(model_description)
 nn_archive = dai.NNArchive(archivePath)
 


### PR DESCRIPTION
Adjusting the HubAI model references to the updated names (switching from HxW to WxH naming convention, removing the "NEW" tags). References of the following models were adjusted:

- XFeat
- YuNet
- QRDet
- Lite-HRNet
- CREStereo

The following models were also checked but no direct references are used in the repo:

- MediaPipe Selfie Segmentation
- Zero-DCE
- DnCNN3
- Depth Anything V2
- MiDaS v2.1
- PP-LiteSeg
- eWaSR