### PR TITLE
fix: generic exeriment and re-identification experiment

### DIFF
--- a/neural-networks/generic-example/main.py
+++ b/neural-networks/generic-example/main.py
@@ -51,15 +51,15 @@ with dai.Pipeline(device) as pipeline:
     )
 
     if args.annotation_mode == "segmentation":
-        annotation_node = pipeline.create(SegAnnotationNode)
-        nn_with_parser.passthrough.link(annotation_node.input_frame)
-        nn_with_parser.out.link(annotation_node.input_segmentation)
-        visualizer.addTopic("Video", annotation_node.out, "images")
+        annotation_node = pipeline.create(SegAnnotationNode).build(
+            nn_with_parser.passthrough, nn_with_parser.out
+        )
+        visualizer.addTopic("Video", annotation_node.output, "images")
     elif args.annotation_mode == "segmentation_with_annotation":
-        annotation_node = pipeline.create(DetSegAnntotationNode)
-        nn_with_parser.passthrough.link(annotation_node.input_frame)
-        nn_with_parser.out.link(annotation_node.input_detections)
-        visualizer.addTopic("Video", annotation_node.out, "images")
+        annotation_node = pipeline.create(DetSegAnntotationNode).build(
+            nn_with_parser.passthrough, nn_with_parser.out
+        )
+        visualizer.addTopic("Video", annotation_node.output, "images")
         visualizer.addTopic("Detections", nn_with_parser.out, "detections")
     else:
         visualizer.addTopic("Video", nn_with_parser.passthrough, "images")

--- a/neural-networks/generic-example/utils/segmentation.py
+++ b/neural-networks/generic-example/utils/segmentation.py
@@ -51,7 +51,9 @@ class SegAnnotationNode(dai.node.HostNode):
 
         colored_frame = cv2.addWeighted(frame, 0.5, colored_mask, 0.5, 0)
 
-        self.output.send(output_frame.setCvFrame(colored_frame, dai.ImgFrame.Type.BGR888i))
+        self.output.send(
+            output_frame.setCvFrame(colored_frame, dai.ImgFrame.Type.BGR888i)
+        )
 
 
 class DetSegAnntotationNode(dai.node.HostNode):
@@ -70,7 +72,6 @@ class DetSegAnntotationNode(dai.node.HostNode):
     def process(self, image_frame_msg: dai.Buffer, detections_msg: dai.Buffer):
         assert isinstance(image_frame_msg, dai.ImgFrame)
         assert isinstance(detections_msg, ImgDetectionsExtended)
-        
 
         time_stamp = image_frame_msg.getTimestamp()
         frame = image_frame_msg.getCvFrame()

--- a/neural-networks/reidentification/human-reidentification/main.py
+++ b/neural-networks/reidentification/human-reidentification/main.py
@@ -35,6 +35,8 @@ with dai.Pipeline(device) as pipeline:
     rec_model_description = dai.NNModelDescription(args.rec_model)
     rec_model_description.platform = platform
     rec_nn_archive = dai.NNArchive(dai.getModelFromZoo(rec_model_description))
+    rec_nn_width = rec_nn_archive.getInputWidth()
+    rec_nn_height = rec_nn_archive.getInputHeight()
 
     # Video/Camera Input Node
     if args.media_path:
@@ -60,11 +62,8 @@ with dai.Pipeline(device) as pipeline:
     )
 
     # Detections Processing Node
-    det_process_node = pipeline.create(ProcessDetections)
-    det_process_node.set_target_size(
-        rec_nn_archive.getInputWidth(), rec_nn_archive.getInputHeight()
-    )
-    det_nn.out.link(det_process_node.detections_input)
+    det_process_node = pipeline.create(ProcessDetections).build(det_nn.out)
+    det_process_node.set_target_size(rec_nn_width, rec_nn_height)
 
     # Crop Configuration Sender Node
     config_sender_node = pipeline.create(dai.node.Script)

--- a/neural-networks/reidentification/human-reidentification/utils/process.py
+++ b/neural-networks/reidentification/human-reidentification/utils/process.py
@@ -1,8 +1,8 @@
 import depthai as dai
-from depthai_nodes.ml.messages import ImgDetectionExtended
+from depthai_nodes.ml.messages import ImgDetectionExtended, ImgDetectionsExtended
 
 
-class ProcessDetections(dai.node.ThreadedHostNode):
+class ProcessDetections(dai.node.HostNode):
     """A host node for processing a list of detections in a two-stage pipeline.
     The node iterates over a list of detections and sends a dai.MessageGroup with
     a list of ImageManipConfigV2 objects that can be executed by the ImageManipV2 node.
@@ -10,7 +10,7 @@ class ProcessDetections(dai.node.ThreadedHostNode):
     Before use, the target size need to be set with the set_target_size method.
     Attributes
     ----------
-    detections_input : dai.Input
+    detections_msg : dai.Input
         The input message for the detections.
     config_output : dai.Output
         The output message for the ImageManipConfigV2 objects.
@@ -21,33 +21,44 @@ class ProcessDetections(dai.node.ThreadedHostNode):
 
     def __init__(self):
         super().__init__()
-        self.detections_input = self.createInput()
-        self.config_output = self.createOutput()
-        self.num_configs_output = self.createOutput()
+        self.config_output = self.createOutput(
+            possibleDatatypes=[
+                dai.Node.DatatypeHierarchy(dai.DatatypeEnum.Buffer, True)
+            ]
+        )
+        self.num_configs_output = self.createOutput(
+            possibleDatatypes=[
+                dai.Node.DatatypeHierarchy(dai.DatatypeEnum.ImageManipConfigV2, True)
+            ]
+        )
 
-    def run(self) -> None:
-        while self.isRunning():
-            img_detections = self.detections_input.get()
-            detections = img_detections.detections
+    def build(self, detections_msg: dai.Node.Output):
+        self.link_args(detections_msg)
+        return self
 
-            num_detections = len(detections)
-            num_cfgs_message = dai.Buffer(num_detections)
+    def process(self, detections_msg: dai.Buffer):
+        assert isinstance(detections_msg, ImgDetectionsExtended)
 
-            num_cfgs_message.setTimestamp(img_detections.getTimestamp())
-            num_cfgs_message.setSequenceNum(img_detections.getSequenceNum())
-            self.num_configs_output.send(num_cfgs_message)
+        detections = detections_msg.detections
 
-            for i, detection in enumerate(detections):
-                cfg = dai.ImageManipConfigV2()
-                detection: ImgDetectionExtended = detection
-                rect = detection.rotated_rect
+        num_detections = len(detections)
+        num_cfgs_message = dai.Buffer(num_detections)
 
-                cfg.addCropRotatedRect(rect, normalizedCoords=True)
-                cfg.setOutputSize(self._target_w, self._target_h)
-                cfg.setReusePreviousImage(False)
-                cfg.setTimestamp(img_detections.getTimestamp())
-                cfg.setSequenceNum(img_detections.getSequenceNum())
-                self.config_output.send(cfg)
+        num_cfgs_message.setTimestamp(detections_msg.getTimestamp())
+        num_cfgs_message.setSequenceNum(detections_msg.getSequenceNum())
+        self.num_configs_output.send(num_cfgs_message)
+
+        for i, detection in enumerate(detections):
+            cfg = dai.ImageManipConfigV2()
+            detection: ImgDetectionExtended = detection
+            rect = detection.rotated_rect
+
+            cfg.addCropRotatedRect(rect, normalizedCoords=True)
+            cfg.setOutputSize(self._target_w, self._target_h)
+            cfg.setReusePreviousImage(False)
+            cfg.setTimestamp(detections_msg.getTimestamp())
+            cfg.setSequenceNum(detections_msg.getSequenceNum())
+            self.config_output.send(cfg)
 
     def set_target_size(self, w: int, h: int):
         """Set the target size for the output image."""


### PR DESCRIPTION
Changes:
- Generic experiment:
    - fix `ImageManipV2.MaxOutputFrameSize()` setting to use stride instead of width - this fixes the experiment for some models that previously errored out with output missmatch error (e.g. `dm-count:shb-426x240` and `rt-super-resolution:50x50`)
    - change the device parameter setting to a more standardized way
    - change host nodes to inherit from `HostNode` instead of `ThreadedHostNode`
- Re-Identification experiment:
    - fix `ImageManipV2.MaxOutputFrameSize()` setting to use stride instead of width
    - error out if running on RVC2 (will be removed once `ImageManipConfigV2` will be able to handle RVC2)
    - remove all `ImageManip` objects (not needed as pipeline is not running on RVC2 currently and `ImageManipV2` will be sufficient after the next DAI update)
    - change `ProcessDetections` host node to inherit from `HostNode` instead of `ThreadedHostNode` (didn't find a way to do it for `AnnotationSyncNode` that syncs outputs of two nn as we need to pull `n` messages from one nn before pulling the next message from the second one)