### PR TITLE
feat: update generic example

### DIFF
--- a/neural-networks/generic-example/main.py
+++ b/neural-networks/generic-example/main.py
@@ -45,19 +45,18 @@ with dai.Pipeline(device) as pipeline:
     )
 
     if args.annotation_mode == "segmentation":
-        annotation_node = pipeline.create(SegAnnotationNode)
-        nn_with_parser.passthrough.link(annotation_node.input_frame)
-        nn_with_parser.out.link(annotation_node.input_segmentation)
-        visualizer.addTopic("Video", annotation_node.out, "images")
+        annotation_node = pipeline.create(SegAnnotationNode).build(
+            nn_with_parser.passthrough, nn_with_parser.out
+        )
+        visualizer.addTopic("Video", annotation_node.output, "images")
     elif args.annotation_mode == "segmentation_with_annotation":
-        annotation_node = pipeline.create(DetSegAnntotationNode)
-        nn_with_parser.passthrough.link(annotation_node.input_frame)
-        nn_with_parser.out.link(annotation_node.input_detections)
-        visualizer.addTopic("Video", annotation_node.out, "images")
+        annotation_node = pipeline.create(DetSegAnntotationNode).build(
+            nn_with_parser.passthrough, nn_with_parser.out
+        )
+        visualizer.addTopic("Video", annotation_node.output, "images")
         visualizer.addTopic("Detections", nn_with_parser.out, "detections")
     else:
         visualizer.addTopic("Video", nn_with_parser.passthrough, "images")
-        visualizer.addTopic("Visualizations", nn_with_parser.out, "images")
 
     print("Pipeline created.")
 

--- a/neural-networks/generic-example/main.py
+++ b/neural-networks/generic-example/main.py
@@ -25,25 +25,19 @@ with dai.Pipeline(device) as pipeline:
     if args.media_path:
         replay = pipeline.create(dai.node.ReplayVideo)
         replay.setReplayVideoFile(Path(args.media_path))
-        replay.setOutFrameType(dai.ImgFrame.Type.NV12)
+        replay.setOutFrameType(
+            dai.ImgFrame.Type.BGR888i
+            if platform == "RVC4"
+            else dai.ImgFrame.Type.BGR888p
+        )
         replay.setLoop(True)
         if args.fps_limit:
             replay.setFps(args.fps_limit)
             args.fps_limit = None  # only want to set it once
-        imageManip = pipeline.create(dai.node.ImageManipV2)
-        imageManip.setMaxOutputFrameSize(
-            nn_archive.getInputWidth() * nn_archive.getInputHeight() * 3
-        )
-        imageManip.initialConfig.setOutputSize(
-            nn_archive.getInputWidth(), nn_archive.getInputHeight()
-        )
-        imageManip.initialConfig.setFrameType(dai.ImgFrame.Type.BGR888p)
-        if platform == "RVC4":
-            imageManip.initialConfig.setFrameType(dai.ImgFrame.Type.BGR888i)
-        replay.out.link(imageManip.inputImage)
+        replay.setSize(nn_archive.getInputWidth(), nn_archive.getInputHeight())
 
     input_node = (
-        imageManip.out if args.media_path else pipeline.create(dai.node.Camera).build()
+        replay.out if args.media_path else pipeline.create(dai.node.Camera).build()
     )
 
     nn_with_parser = pipeline.create(ParsingNeuralNetwork).build(

--- a/neural-networks/generic-example/requirements.txt
+++ b/neural-networks/generic-example/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a11
-depthai-nodes>=0.1.1
+depthai>=3.0.0a13
+depthai-nodes>=0.1.2

--- a/neural-networks/generic-example/utils/segmentation.py
+++ b/neural-networks/generic-example/utils/segmentation.py
@@ -5,83 +5,83 @@ from depthai_nodes.ml.messages import SegmentationMask
 from depthai_nodes.ml.messages import ImgDetectionsExtended
 
 
-class SegAnnotationNode(dai.node.ThreadedHostNode):
+class SegAnnotationNode(dai.node.HostNode):
     def __init__(self):
         super().__init__()
+        self.output = self.createOutput(
+            possibleDatatypes=[
+                dai.Node.DatatypeHierarchy(dai.DatatypeEnum.ImgFrame, True)
+            ]
+        )
 
-        self.input_segmentation = self.createInput()
-        self.input_frame = self.createInput()
+    def build(
+        self, image_frame_msg: dai.Node.Output, segmentation_msg: dai.Node.Output
+    ):
+        self.link_args(image_frame_msg, segmentation_msg)
+        return self
 
-        self.out = self.createOutput()
+    def process(self, image_frame_msg: dai.Buffer, segmentation_msg: dai.Buffer):
+        assert isinstance(image_frame_msg, dai.ImgFrame)
+        assert isinstance(segmentation_msg, SegmentationMask)
 
-    def run(self):
-        while self.isRunning():
-            mask = self.input_segmentation.get()
-            frame = self.input_frame.get().getCvFrame()
-            output_frame = dai.ImgFrame()
+        frame = image_frame_msg.getCvFrame()
+        output_frame = dai.ImgFrame()
 
-            if not isinstance(mask, SegmentationMask):
-                raise ValueError(
-                    f"Invalid input type. Expected SegmentationMask, got {type(mask)}"
+        mask = segmentation_msg.mask
+        unique_values = np.unique(mask[mask >= 0])
+        scaled_mask = np.zeros_like(mask, dtype=np.uint8)
+
+        if unique_values.size != 0:
+            min_val, max_val = unique_values.min(), unique_values.max()
+
+            if min_val == max_val:
+                scaled_mask = np.ones_like(mask, dtype=np.uint8) * 255
+            else:
+                scaled_mask = ((mask - min_val) / (max_val - min_val) * 255).astype(
+                    np.uint8
                 )
+            scaled_mask[mask == -1] = 0
+        colored_mask = cv2.applyColorMap(scaled_mask, cv2.COLORMAP_RAINBOW)
+        colored_mask[mask == -1] = [0, 0, 0]
 
-            mask = mask.mask
-            unique_values = np.unique(mask[mask >= 0])
-            scaled_mask = np.zeros_like(mask, dtype=np.uint8)
+        frame_height, frame_width, _ = frame.shape
+        colored_mask = cv2.resize(
+            colored_mask, (frame_width, frame_height), interpolation=cv2.INTER_AREA
+        )
 
-            if unique_values.size != 0:
-                min_val, max_val = unique_values.min(), unique_values.max()
+        colored_frame = cv2.addWeighted(frame, 0.5, colored_mask, 0.5, 0)
 
-                if min_val == max_val:
-                    scaled_mask = np.ones_like(mask, dtype=np.uint8) * 255
-                else:
-                    scaled_mask = ((mask - min_val) / (max_val - min_val) * 255).astype(
-                        np.uint8
-                    )
-                scaled_mask[mask == -1] = 0
-            colored_mask = cv2.applyColorMap(scaled_mask, cv2.COLORMAP_RAINBOW)
-            colored_mask[mask == -1] = [0, 0, 0]
-
-            frame_height, frame_width, _ = frame.shape
-            colored_mask = cv2.resize(
-                colored_mask, (frame_width, frame_height), interpolation=cv2.INTER_AREA
-            )
-
-            colored_frame = cv2.addWeighted(frame, 0.5, colored_mask, 0.5, 0)
-
-            self.out.send(
-                output_frame.setCvFrame(colored_frame, dai.ImgFrame.Type.BGR888i)
-            )
+        self.output.send(
+            output_frame.setCvFrame(colored_frame, dai.ImgFrame.Type.BGR888i)
+        )
 
 
-class DetSegAnntotationNode(dai.node.ThreadedHostNode):
+class DetSegAnntotationNode(dai.node.HostNode):
     def __init__(self):
         super().__init__()
+        self.output = self.createOutput(
+            possibleDatatypes=[
+                dai.Node.DatatypeHierarchy(dai.DatatypeEnum.ImgFrame, True)
+            ]
+        )
 
-        self.input_detections = self.createInput()
-        self.input_frame = self.createInput()
+    def build(self, image_frame_msg: dai.Node.Output, detections_msg: dai.Node.Output):
+        self.link_args(image_frame_msg, detections_msg)
+        return self
 
-        self.out = self.createOutput()
+    def process(self, image_frame_msg: dai.Buffer, detections_msg: dai.Buffer):
+        assert isinstance(image_frame_msg, dai.ImgFrame)
+        assert isinstance(detections_msg, ImgDetectionsExtended)
 
-    def run(self):
-        while self.isRunning():
-            extended_detections = self.input_detections.get()
-            frame = self.input_frame.get()
-            time_stamp = frame.getTimestamp()
-            frame = frame.getCvFrame()
-            output_frame = dai.ImgFrame()
+        time_stamp = image_frame_msg.getTimestamp()
+        frame = image_frame_msg.getCvFrame()
+        output_frame = dai.ImgFrame()
 
-            if not isinstance(extended_detections, ImgDetectionsExtended):
-                raise ValueError(
-                    f"Invalid input type. Expected ImgDetectionsExtended, got {type(extended_detections)}"
-                )
-
-            label_mask = extended_detections.masks
-            detections = extended_detections.detections
-            if len(label_mask.shape) < 2:
-                self.out.send(output_frame.setCvFrame(frame, dai.ImgFrame.Type.BGR888i))
-                continue
-
+        label_mask = detections_msg.masks
+        detections = detections_msg.detections
+        if len(label_mask.shape) < 2:
+            self.out.send(output_frame.setCvFrame(frame, dai.ImgFrame.Type.BGR888i))
+        else:
             detection_labels = {
                 idx: detection.label for idx, detection in enumerate(detections)
             }
@@ -101,6 +101,6 @@ class DetSegAnntotationNode(dai.node.ThreadedHostNode):
             colored_frame = cv2.addWeighted(frame, 0.5, color_mask, 0.5, 0)
 
             output_frame.setTimestamp(time_stamp)
-            self.out.send(
+            self.output.send(
                 output_frame.setCvFrame(colored_frame, dai.ImgFrame.Type.BGR888i)
             )


### PR DESCRIPTION
## Purpose
Adjust the generic example to the recent updates in **DAI (3.0.0a13)**:
- `ReplayVideo` node can be used as input to `ParsingNeuralNetwork`;
- host nodes should inherit from `HostNode` instead of `ThreadedHostNode`.

## Specification
Removed `ImageManip` node after the `ReplayVideo` node, and adjusted the `SegAnnotationNode` and `DetSegAnntotationNode` to inherit from the `HostNode`.

## Dependencies & Potential Impact
None.

## Deployment Plan
None.

## Testing & Validation
Tested the example on the following models:
- `luxonis/dm-count:shb-426x240` due to past problems with stride;
- `luxonis/rt-super-resolution:50x50` due to past problems with stride;
- `luxonis/deeplab-v3-plus:256x256` for segmentation mode;
- `luxonis/yolov8-instance-segmentation-nano:coco-512x288` for segmentation_with_annotation mode.
