### PR TITLE
Gen3: YOLO-host-decoding - Bug fix.

### DIFF
--- a/neural-networks/object-detection/yolo-host-decoding/main.py
+++ b/neural-networks/object-detection/yolo-host-decoding/main.py
@@ -46,6 +46,9 @@ with dai.Pipeline(device) as pipeline:
     manip = pipeline.create(dai.node.ImageManipV2)
     manip.initialConfig.setOutputSize(*nn_archive.getInputSize())
     manip.initialConfig.setFrameType(frame_type)
+    manip.setMaxOutputFrameSize(
+        nn_archive.getInputWidth() * nn_archive.getInputHeight() * 3
+    )
     input_node.link(manip.inputImage)
 
     nn = pipeline.create(dai.node.NeuralNetwork).build(manip.out, nn_archive)


### PR DESCRIPTION
## Purpose
Add the `setMaxOutputFrameSize` so we can also use 640x640 YOLO for example.

## Specification
None / not applicable

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
None / not applicable