### PR TITLE
Gen3: Stream manipulation standalone mode

### DIFF
--- a/stream-manipulation/mjpeg-streaming/utils/mjpeg_streamer.py
+++ b/stream-manipulation/mjpeg-streaming/utils/mjpeg_streamer.py
@@ -1,8 +1,10 @@
 import threading
 from typing import List
+
 import cv2
 import depthai as dai
 import numpy as np
+
 from utils.server import ThreadedHTTPServer, VideoStreamHandler
 
 HTTP_SERVER_PORT = 8083
@@ -24,7 +26,7 @@ class MJPEGStreamer(dai.node.HostNode):
 
         # Start server
         self.server = ThreadedHTTPServer(
-            ("localhost", HTTP_SERVER_PORT), VideoStreamHandler
+            ("0.0.0.0", HTTP_SERVER_PORT), VideoStreamHandler
         )
         self.labels = labels
         th = threading.Thread(target=self.server.serve_forever)

--- a/stream-manipulation/on-device-encoding/README.md
+++ b/stream-manipulation/on-device-encoding/README.md
@@ -49,11 +49,18 @@ This will run the On Device Encoding experiment with the default device, H265 co
 
 ### Standalone Mode
 
-Running the experiment in the [Standalone mode](https://rvc4.docs.luxonis.com/software/depthai/standalone/) runs the app entirely on the device.
+Running the example in the [Standalone mode](https://rvc4.docs.luxonis.com/software/depthai/standalone/), app runs entirely on the device.
 To run the example in this mode, first install the [oakctl](https://rvc4.docs.luxonis.com/software/tools/oakctl/) command-line tool (enables host-device interaction) as:
 
 ```bash
 bash -c "$(curl -fsSL https://oakctl-releases.luxonis.com/oakctl-installer.sh)"
 ```
 
-# TODO: add instructions for standalone mode once oakctl supports CLI arguments
+The app can then be run with:
+
+```bash
+oakctl connect <DEVICE_IP>
+oakctl app run .
+```
+
+This will run the experiment with default argument values. If you want to change these values you need to edit the `oakapp.toml` file.

--- a/stream-manipulation/on-device-encoding/main.py
+++ b/stream-manipulation/on-device-encoding/main.py
@@ -35,8 +35,8 @@ with dai.Pipeline(device) as pipeline:
         output_path=args.output,
     )
 
-    # Visualizer doesn't support H265, so we need to use camera stream for H265 videos
-    if args.codec == "h265":
+    # Visualizer currently doesn't support H265 or any encoded videos in RVC4 standalone mode - use non-encoded streams instead
+    if args.codec == "h265" or device.getPlatform() == dai.Platform.RVC4:
         visualizer.addTopic("Video", cam_out, "images")
     else:
         visualizer.addTopic("Video", video_enc.out, "images")

--- a/stream-manipulation/on-device-encoding/oakapp.toml
+++ b/stream-manipulation/on-device-encoding/oakapp.toml
@@ -1,0 +1,13 @@
+identifier = "com.luxonis.on-device-encoding"
+app_version = "1.0.0"
+
+prepare_container = [
+    { type = "RUN", command = "apt-get update" },
+    { type = "RUN", command = "apt-get install -y python3 python3-pip libglib2.0-0 libgl1-mesa-glx wget" },
+]
+
+prepare_build_container = []
+
+build_steps = ["pip3 install -r /app/requirements.txt --break-system-packages"]
+
+entrypoint = ["bash", "-c", "python3 /app/main.py"]

--- a/stream-manipulation/on-device-encoding/utils/arguments.py
+++ b/stream-manipulation/on-device-encoding/utils/arguments.py
@@ -31,7 +31,7 @@ def initialize_argparser():
         choices=["h264", "h265", "mjpeg"],
         default="h264",
         type=str,
-        help="Video encoding (h264 is default)",
+        help="Video encoding",
     )
 
     parser.add_argument(

--- a/stream-manipulation/rtsp-streaming/README.md
+++ b/stream-manipulation/rtsp-streaming/README.md
@@ -62,11 +62,18 @@ ffplay -fflags nobuffer -fflags discardcorrupt -flags low_delay -framedrop rtsp:
 
 ### Standalone Mode
 
-Running the experiment in the [Standalone mode](https://rvc4.docs.luxonis.com/software/depthai/standalone/) runs the app entirely on the device.
+Running the example in the [Standalone mode](https://rvc4.docs.luxonis.com/software/depthai/standalone/), app runs entirely on the device.
 To run the example in this mode, first install the [oakctl](https://rvc4.docs.luxonis.com/software/tools/oakctl/) command-line tool (enables host-device interaction) as:
 
 ```bash
 bash -c "$(curl -fsSL https://oakctl-releases.luxonis.com/oakctl-installer.sh)"
 ```
 
-# TODO: add instructions for standalone mode once oakctl supports CLI arguments
+The app can then be run with:
+
+```bash
+oakctl connect <DEVICE_IP>
+oakctl app run .
+```
+
+This will run the experiment with default argument values. If you want to change these values you need to edit the `oakapp.toml` file.

--- a/stream-manipulation/rtsp-streaming/oakapp.toml
+++ b/stream-manipulation/rtsp-streaming/oakapp.toml
@@ -1,0 +1,13 @@
+identifier = "com.luxonis.stream-manipulation.rtsp-streaming"
+app_version = "1.0.0"
+
+prepare_container = [
+    { type = "RUN", command = "apt-get update" },
+    { type = "RUN", command = "apt-get install -y python3 python3-pip libglib2.0-0 libgl1-mesa-glx wget git libgirepository1.0-dev libcairo2-dev gstreamer-1.0 gir1.2-gst-rtsp-server-1.0" },
+]
+
+prepare_build_container = []
+
+build_steps = ["pip3 install -r /app/requirements.txt --break-system-packages"]
+
+entrypoint = ["bash", "-c", "python3 /app/main.py"]

--- a/stream-manipulation/rtsp-streaming/requirements.txt
+++ b/stream-manipulation/rtsp-streaming/requirements.txt
@@ -1,3 +1,4 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai==3.0.0a12
+depthai==3.0.0a15
+numpy>=1.22
 PyGObject==3.46.0

--- a/stream-manipulation/webrtc-streaming/README.md
+++ b/stream-manipulation/webrtc-streaming/README.md
@@ -41,11 +41,18 @@ python3 main.py
 
 ### Standalone Mode
 
-Running the experiment in the [Standalone mode](https://rvc4.docs.luxonis.com/software/depthai/standalone/) runs the app entirely on the device.
+Running the example in the [Standalone mode](https://rvc4.docs.luxonis.com/software/depthai/standalone/), app runs entirely on the device.
 To run the example in this mode, first install the [oakctl](https://rvc4.docs.luxonis.com/software/tools/oakctl/) command-line tool (enables host-device interaction) as:
 
 ```bash
 bash -c "$(curl -fsSL https://oakctl-releases.luxonis.com/oakctl-installer.sh)"
 ```
 
-# TODO: add instructions for standalone mode once oakctl supports CLI arguments
+The app can then be run with:
+
+```bash
+oakctl connect <DEVICE_IP>
+oakctl app run .
+```
+
+This will run the experiment with default argument values. If you want to change these values you need to edit the `oakapp.toml` file.

--- a/stream-manipulation/webrtc-streaming/oakapp.toml
+++ b/stream-manipulation/webrtc-streaming/oakapp.toml
@@ -1,0 +1,13 @@
+identifier = "com.luxonis.stream-manipulation.webrtc-streaming"
+app_version = "1.0.0"
+
+prepare_container = [
+    { type = "RUN", command = "apt-get update" },
+    { type = "RUN", command = "apt-get install -y python3 python3-pip libglib2.0-0 libgl1-mesa-glx wget git" },
+]
+
+prepare_build_container = []
+
+build_steps = ["pip3 install -r /app/requirements.txt --break-system-packages"]
+
+entrypoint = ["bash", "-c", "python3 /app/main.py"]


### PR DESCRIPTION
## Purpose
Add missing standalone mode to `stream-manipulation` experiments

## Testing & Validation
Tested on RVC4