### PR TITLE
feat: abstract input setting

### DIFF
--- a/neural-networks/generic-example/main.py
+++ b/neural-networks/generic-example/main.py
@@ -1,8 +1,8 @@
-from pathlib import Path
 import depthai as dai
 from depthai_nodes.node import ParsingNeuralNetwork, ImgFrameOverlay, ApplyColormap
 
 from utils.arguments import initialize_argparser
+from utils.input import create_input_node
 
 _, args = initialize_argparser()
 
@@ -21,22 +21,10 @@ with dai.Pipeline(device) as pipeline:
         )
     )
 
-    if args.media_path:
-        replay = pipeline.create(dai.node.ReplayVideo)
-        replay.setReplayVideoFile(Path(args.media_path))
-        replay.setOutFrameType(
-            dai.ImgFrame.Type.BGR888i
-            if platform == "RVC4"
-            else dai.ImgFrame.Type.BGR888p
-        )
-        replay.setLoop(True)
-        if args.fps_limit:
-            replay.setFps(args.fps_limit)
-            args.fps_limit = None  # only want to set it once
-        replay.setSize(nn_archive.getInputWidth(), nn_archive.getInputHeight())
-
-    input_node = (
-        replay.out if args.media_path else pipeline.create(dai.node.Camera).build()
+    input_node = create_input_node(
+        pipeline,
+        platform,
+        args.media_path,
     )
 
     nn_with_parser = pipeline.create(ParsingNeuralNetwork).build(

--- a/neural-networks/generic-example/utils/input.py
+++ b/neural-networks/generic-example/utils/input.py
@@ -1,0 +1,31 @@
+import depthai as dai
+from pathlib import Path
+
+
+def create_input_node(pipeline, platform, media_path=None, media_loop=True):
+    """Adds a ReplayVideo or a Camera node to the pipeline."""
+
+    def _create_media_node(pipeline, media_path, platform, loop):
+        """Add a ReplayVideo node."""
+
+        replay = pipeline.create(dai.node.ReplayVideo)
+        replay.setReplayVideoFile(Path(media_path))
+        if platform == "RVC2":
+            replay.setOutFrameType(dai.ImgFrame.Type.BGR888p)
+        elif platform == "RVC4":
+            replay.setOutFrameType(dai.ImgFrame.Type.BGR888i)
+        else:
+            raise ValueError(f"ReplayVideo node not supported for {platform}.")
+        replay.setLoop(loop)
+        return replay
+
+    def _create_camera_node(pipeline):
+        """Add a Camera node."""
+
+        cam = pipeline.create(dai.node.Camera)
+        return cam.build()
+
+    if media_path:
+        return _create_media_node(pipeline, media_path, platform, media_loop)
+    else:
+        return _create_camera_node(pipeline)


### PR DESCRIPTION
## Purpose
There is a lot of code repetition between experiments for input node setting (the procedure of creating either a `dai.node.Camera` or `dai.node.ReplayVideo` node is virtually the same for every experiment).

## Specification
Adding the `create_input_node` function to abstract the input node setting.
TODO:

- utilize the function in all of the experiments within the neural-networks folder,
- discuss if the `create_input_node` function should be moved to `depthai-nodes`.

## Dependencies & Potential Impact
None

## Deployment Plan
None

## Testing & Validation
Running the experiment(s) using the default settings.