### PR TITLE
Fix Gen3: Depthai Version

### DIFF
--- a/custom-frontend/raw-stream/requirements.txt
+++ b/custom-frontend/raw-stream/requirements.txt
@@ -1,3 +1,3 @@
---extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local
-depthai==3.0.0a15
+--extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local
+depthai==3.0.0a15.dev0+adc7ca692eef7dae97593176cb1f977eed6f8837
 numpy>=1.22

--- a/depth-measurement/calc-spatial-on-host/requirements.txt
+++ b/depth-measurement/calc-spatial-on-host/requirements.txt
@@ -1,5 +1,5 @@
---extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai==3.0.0a15
+--extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
+depthai==3.0.0a15.dev0+adc7ca692eef7dae97593176cb1f977eed6f8837
 depthai-nodes==0.2.1
 opencv-python-headless==4.10.0.84
 numpy>=1.22

--- a/depth-measurement/stereo-on-host/requirements.txt
+++ b/depth-measurement/stereo-on-host/requirements.txt
@@ -1,5 +1,5 @@
---extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai==3.0.0a15
+--extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
+depthai==3.0.0a15.dev0+adc7ca692eef7dae97593176cb1f977eed6f8837
 opencv-python-headless~=4.10.0
 depthai-nodes~=0.2.1
 scikit-image

--- a/depth-measurement/stereo-on-host/requirements.txt
+++ b/depth-measurement/stereo-on-host/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a15
+depthai==3.0.0a15
 opencv-python-headless~=4.10.0
 depthai-nodes~=0.2.1
 scikit-image

--- a/depth-measurement/triangulation/requirements.txt
+++ b/depth-measurement/triangulation/requirements.txt
@@ -1,5 +1,5 @@
---extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai==3.0.0a15
+--extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
+depthai==3.0.0a15.dev0+adc7ca692eef7dae97593176cb1f977eed6f8837
 depthai-nodes==0.2.1
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/3D-detection/objectron/requirements.txt
+++ b/neural-networks/3D-detection/objectron/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a14
+depthai==3.0.0a14
 depthai-nodes~=0.2.0

--- a/neural-networks/counting/crowdcounting/requirements.txt
+++ b/neural-networks/counting/crowdcounting/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/facial-detection/age-gender/requirements.txt
+++ b/neural-networks/facial-detection/age-gender/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0

--- a/neural-networks/facial-detection/blur-faces/requirements.txt
+++ b/neural-networks/facial-detection/blur-faces/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/facial-detection/emotion-recognition/requirements.txt
+++ b/neural-networks/facial-detection/emotion-recognition/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0
 numpy>=1.22

--- a/neural-networks/facial-detection/face-mask-detection/requirements.txt
+++ b/neural-networks/facial-detection/face-mask-detection/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0

--- a/neural-networks/facial-detection/fatigue-detection/requirements.txt
+++ b/neural-networks/facial-detection/fatigue-detection/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/facial-detection/gaze-estimation/requirements.txt
+++ b/neural-networks/facial-detection/gaze-estimation/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0

--- a/neural-networks/feature-detection/xfeat/requirements.txt
+++ b/neural-networks/feature-detection/xfeat/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/generic-example/requirements.txt
+++ b/neural-networks/generic-example/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/object-detection/human-machine-safety/requirements.txt
+++ b/neural-networks/object-detection/human-machine-safety/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0

--- a/neural-networks/object-detection/social-distancing/requirements.txt
+++ b/neural-networks/object-detection/social-distancing/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/object-detection/spatial-detections/requirements.txt
+++ b/neural-networks/object-detection/spatial-detections/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0

--- a/neural-networks/object-detection/text-blur/requirements.txt
+++ b/neural-networks/object-detection/text-blur/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/object-detection/thermal-detection/requirements.txt
+++ b/neural-networks/object-detection/thermal-detection/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0

--- a/neural-networks/object-detection/yolo-host-decoding/requirements.txt
+++ b/neural-networks/object-detection/yolo-host-decoding/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a12
+depthai==3.0.0a12
 numpy>=1.22

--- a/neural-networks/object-detection/yolo-p/requirements.txt
+++ b/neural-networks/object-detection/yolo-p/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/object-detection/yolo-world/requirements.txt
+++ b/neural-networks/object-detection/yolo-world/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a13
+depthai==3.0.0a13
 depthai-nodes~=0.2.0
 onnxruntime
 transformers

--- a/neural-networks/pose-estimation/animal-pose/requirements.txt
+++ b/neural-networks/pose-estimation/animal-pose/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a14
+depthai==3.0.0a14
 depthai-nodes~=0.2.0

--- a/neural-networks/pose-estimation/hand-pose/requirements.txt
+++ b/neural-networks/pose-estimation/hand-pose/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a14
+depthai==3.0.0a14
 depthai-nodes~=0.2.0

--- a/neural-networks/pose-estimation/human-pose/requirements.txt
+++ b/neural-networks/pose-estimation/human-pose/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a14
+depthai==3.0.0a14
 depthai-nodes~=0.2.0

--- a/neural-networks/reidentification/human-reidentification/requirements.txt
+++ b/neural-networks/reidentification/human-reidentification/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a14
+depthai==3.0.0a14
 depthai-nodes~=0.2.0
 numpy>=1.22

--- a/neural-networks/segmentation/depth-crop/requirements.txt
+++ b/neural-networks/segmentation/depth-crop/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai>=3.0.0a14
+depthai==3.0.0a14
 depthai-nodes~=0.2.0

--- a/stream-manipulation/rtsp-streaming/requirements.txt
+++ b/stream-manipulation/rtsp-streaming/requirements.txt
@@ -1,4 +1,4 @@
---extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
-depthai==3.0.0a15
+--extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
+depthai==3.0.0a15.dev0+adc7ca692eef7dae97593176cb1f977eed6f8837
 numpy>=1.22
 PyGObject==3.46.0


### PR DESCRIPTION
## Purpose
Solves the issue with standalone mode introduced in Visualizer version that is present in DepthAI 3.0.0alpha15.

## Specification
Many `requirements.txt` are change to either pin their current version or use fixed alpha15 snapshot version.

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
Experiments where the replace with snapshot version was performed were tested. Those where only change was pinning the DepthAI version were not tested as they are expected to be working on the version they were developed for.