### PR TITLE
Fatigue detection: Update fps limit argument to 30 FPS

### DIFF
--- a/neural-networks/facial-detection/fatigue-detection/utils/arguments.py
+++ b/neural-networks/facial-detection/fatigue-detection/utils/arguments.py
@@ -18,7 +18,7 @@ def initialize_argparser():
         "--fps_limit",
         help="FPS limit for the model runtime.",
         required=False,
-        default=5,
+        default=30,
         type=int,
     )
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Argument was set to 5 instead of 30 by default. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable