### PR TITLE
remove dai.RotatedRect.denormalize() from general OCR

### DIFF
--- a/neural-networks/ocr/general-ocr/utils/host_process_detections.py
+++ b/neural-networks/ocr/general-ocr/utils/host_process_detections.py
@@ -153,13 +153,12 @@ class CropConfigsCreator(dai.node.HostNode):
             if detection.confidence > 0.8:
                 rect = detection.rotated_rect
                 rect = self._expand_rect(rect)
-                rect = rect.denormalize(self.w, self.h)
 
                 xmin, ymin, xmax, ymax = rect.getOuterRect()
-                xmin = int(max(0, xmin))
-                ymin = int(max(0, ymin))
-                xmax = int(min(self.w, xmax))
-                ymax = int(min(self.h, ymax))
+                xmin = int(max(0, xmin * self.w))
+                ymin = int(max(0, ymin * self.h))
+                xmax = int(min(self.w, xmax * self.w))
+                ymax = int(min(self.h, ymax * self.h))
 
                 if xmax - xmin < 50 or ymax - ymin < 12:
                     continue


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Under certain circumstances (and for some reason only only on RVC2) depthai would throw `RuntimeError: Cannot denormalize RotatedRect with mixed normalization` . This happened if text was rotated and on the edge of frame, causing one of the corner points to be outside of the frame bounds, leading to mixed precision (one points' coordinates > 1, the rest < 1). For some reason same issue was not replicated on RVC4.
 
## Specification 
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable