### PR TITLE
Update FPS limits on RVC4

### DIFF
--- a/neural-networks/face-detection/age-gender/main.py
+++ b/neural-networks/face-detection/age-gender/main.py
@@ -26,7 +26,7 @@ frame_type = (
 )
 
 if args.fps_limit is None:
-    args.fps_limit = 5 if platform == "RVC2" else 25
+    args.fps_limit = 5 if platform == "RVC2" else 30
     print(
         f"\nFPS limit set to {args.fps_limit} for {platform} platform. If you want to set a custom FPS limit, use the --fps_limit flag.\n"
     )

--- a/neural-networks/face-detection/blur-faces/main.py
+++ b/neural-networks/face-detection/blur-faces/main.py
@@ -54,7 +54,6 @@ with dai.Pipeline(device) as pipeline:
     det_nn.passthrough.link(blur_node.input_frame)
 
     # visualization
-    visualizer.addTopic("Video", det_nn.passthrough)
     visualizer.addTopic("FaceBlur", blur_node.out)
 
     print("Pipeline created.")

--- a/neural-networks/face-detection/blur-faces/utils/blur_detections.py
+++ b/neural-networks/face-detection/blur-faces/utils/blur_detections.py
@@ -63,5 +63,6 @@ class BlurBboxes(dai.node.ThreadedHostNode):
             img = dai.ImgFrame()
             img.setCvFrame(frame_copy, frame_type)
             img.setTimestamp(ts)
+            img.setSequenceNum(frame.getSequenceNum())
 
             self.out.send(img)

--- a/neural-networks/face-detection/fatigue-detection/main.py
+++ b/neural-networks/face-detection/fatigue-detection/main.py
@@ -26,7 +26,7 @@ frame_type = (
 )
 
 if args.fps_limit is None:
-    args.fps_limit = 5 if platform == "RVC2" else 7
+    args.fps_limit = 5 if platform == "RVC2" else 30
     print(
         f"\nFPS limit set to {args.fps_limit} for {platform} platform. If you want to set a custom FPS limit, use the --fps_limit flag.\n"
     )

--- a/neural-networks/face-detection/head-posture-detection/main.py
+++ b/neural-networks/face-detection/head-posture-detection/main.py
@@ -26,7 +26,7 @@ frame_type = (
 )
 
 if args.fps_limit is None:
-    args.fps_limit = 10 if platform == "RVC2" else 10
+    args.fps_limit = 10 if platform == "RVC2" else 30
     print(
         f"\nFPS limit set to {args.fps_limit} for {platform} platform. If you want to set a custom FPS limit, use the --fps_limit flag.\n"
     )


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Some experiments had very low FPS limist for RVC4 ( 5-7 FPS). This PR increases those limits to 30 fps. Additionally I noticed on blur-faces experiment  a missing setSequenceNumber() and a double output to the visualizer. 
 
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable