### PR TITLE
[FIX] Increasing annotation lag in whisper experiment

### DIFF
--- a/neural-networks/speech-recognition/whisper-tiny-en/utils/annotation_node.py
+++ b/neural-networks/speech-recognition/whisper-tiny-en/utils/annotation_node.py
@@ -21,6 +21,16 @@ class AnnotationNode(dai.node.ThreadedHostNode):
         )
 
         self.annotations = AnnotationHelper()
+        self.annotations.draw_text(
+            "Press 'r' to record audio",
+            (
+                0.002,
+                0.05,
+            ),
+            size=24,
+            color=dai.Color(1, 1, 1, 1),
+            background_color=dai.Color(0, 0, 0, 0.5),
+        )
 
     def parser_text(self, text: str) -> tuple[str, str]:
         """Parses text into tuples of (str, color) and returns the new color of LED (None if not detected or multiple detected)."""
@@ -71,6 +81,16 @@ class AnnotationNode(dai.node.ThreadedHostNode):
                     self.color_output.send(color_msg)
 
                     self.annotations = AnnotationHelper()
+                    self.annotations.draw_text(
+                        "Press 'r' to record audio",
+                        (
+                            0.002,
+                            0.05,
+                        ),
+                        size=24,
+                        color=dai.Color(1, 1, 1, 1),
+                        background_color=dai.Color(0, 0, 0, 0.5),
+                    )
                     color = np.array(color) / 255.0
                     dai_text_color = dai.Color(color[0], color[1], color[2], 1.0)
                     dai_frame_color = dai.Color(color[0], color[1], color[2], 0.2)
@@ -89,16 +109,6 @@ class AnnotationNode(dai.node.ThreadedHostNode):
                         thickness=0.0,
                     )
 
-            self.annotations.draw_text(
-                "Press 'r' to record audio",
-                (
-                    0.002,
-                    0.05,
-                ),
-                size=24,
-                color=dai.Color(1, 1, 1, 1),
-                background_color=dai.Color(0, 0, 0, 0.5),
-            )
             annotations_msg = self.annotations.build(
                 timestamp=frame_msg.getTimestamp(),
                 sequence_num=frame_msg.getSequenceNum(),


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
In PR #689  text annotations for "Press 'r' to record audio" are appended to the previous list of annotations for each new frame. This causes massive lag after a short time. This PR just moves where that text is generated.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable