### PR TITLE
fix: Examples wouldn't work out of the box on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Examples didn't work on windows that have default settings for git configured.

You would get errors like the below:
```sh
    [2025-12-18T13:14:45Z] 2025/12/18 13:14:45 [error] 40#40: *2 connect() failed (111: Connection refused) while connecting to upstream, client: ::1, server: _, request: "GET / HTTP/1.1", upstream: "http://127.0.0.1:8082/", host: "localhost:9000", referrer: "http://localhost:9000/"
    [2025-12-18T13:14:45Z] runsv backend: fatal: unable to start ./run: file does not exist
```

That happened because git is configured to auto convert LF to CRLF on windows when cloning the repository.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Added `.gitattributes` that configures this repo to explicitly convert text files to LF on clone.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Tested in windows VM by cloning my branch and running `oakctl app run .` in `apps/default-app`