### PR TITLE
Added udev package and time syncing to the publish workflow docker image

### DIFF
--- a/.github/ci/publish_oakapp/Dockerfile
+++ b/.github/ci/publish_oakapp/Dockerfile
@@ -1,14 +1,25 @@
 FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash \
-    ca-certificates \
-    findutils \
-    grep \
-    sed \
-  && mkdir -p /etc/udev/rules.d \
+  bash \
+  ca-certificates \
+  findutils \
+  grep \
+  sed \
+  ntpsec-ntpdate \
+  sudo \
+  udev \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp/oak-examples
 
-ENTRYPOINT ["/bin/bash", "/tmp/oak-examples/.github/ci/publish_oakapp/publish_oakapp.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "set -euo pipefail; \
+  echo 'Syncing container clock...'; \
+  if command -v ntpdate >/dev/null 2>&1; then \
+  ntpdate -u pool.ntp.org || true; \
+  elif command -v ntpsec-ntpdate >/dev/null 2>&1; then \
+  ntpsec-ntpdate -qu pool.ntp.org || true; \
+  else \
+  echo 'No ntpdate/ntpsec-ntpdate available; skipping.'; \
+  fi; \
+  exec /tmp/oak-examples/.github/ci/publish_oakapp/publish_oakapp.sh"]


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- added udev (and some other packages) to Dockerfile because of oakctl requirements
- added device-host time sync due to container having wrong "default" time at startup

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable