### PR TITLE
Fix: Numpy change from 2.3 to 2.4

### DIFF
--- a/neural-networks/object-tracking/kalman/utils/kalman_filter_node.py
+++ b/neural-networks/object-tracking/kalman/utils/kalman_filter_node.py
@@ -90,6 +90,8 @@ class KalmanFilterNode(dai.node.HostNode):
 
                 vec_bbox = self._kalman_filters[t.id]["bbox"].x
                 vec_space = self._kalman_filters[t.id]["space"].x
+                vec_bbox = vec_bbox.flatten()
+                vec_space = vec_space.flatten()
 
                 x1_filter = (vec_bbox[0] - vec_bbox[2] / 2) / img_frame.getWidth()
                 x2_filter = (vec_bbox[0] + vec_bbox[2] / 2) / img_frame.getWidth()


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Going from numpy 2.3 to numpy 2.4 the access to 1 dim array with single value was changed so creating a tuple like ([float], [float]) would keep it as such even if the tuple is defined as tuple(float, float). This would cause a [crash](https://github.com/luxonis/oak-examples/actions/runs/20980425572/job/60304045157) :

```
terminate called after throwing an instance of 'pybind11::error_already_set'
  what():  TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. depthai.Point2f()
    2. depthai.Point2f(x: float, y: float)
    3. depthai.Point2f(x: float, y: float, normalized: bool)

Invoked with: array([0.89453125]), array([0.]), True
```

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->

There is potentially other broken examples. A more stable solution would be to remove the `Point = Tuple[float, float]` from [depthai-nodes](https://github.com/luxonis/depthai-nodes/blob/e7c27c47ad3005ef2b1042f3d2fae80c832b6224/depthai_nodes/utils/annotation_helper.py#L13) as that was the way the bug got into annotations.
