### PR TITLE
uvc: clone uvc-gadget submodule with https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cpp/uvc/uvc-gadget"]
 	path = cpp/uvc/uvc-gadget
-	url = git@github.com:luxonis/uvc-gadget.git
+	url = https://github.com/luxonis/uvc-gadget.git


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Since we want this to be a public repo, use `https` instead of `git` protocol to clone `uvc-gadget` library.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable