### PR TITLE
setMaxOutputFrameSize in QR-With-Tiling example

### DIFF
--- a/tutorials/qr-with-tiling/main.py
+++ b/tutorials/qr-with-tiling/main.py
@@ -56,6 +56,9 @@ with dai.Pipeline(device) as pipeline:
     if platform == dai.Platform.RVC4:
         interleaved_manip = pipeline.create(dai.node.ImageManip)
         interleaved_manip.initialConfig.setFrameType(dai.ImgFrame.Type.BGR888i)
+        interleaved_manip.setMaxOutputFrameSize(
+            nn_archive.getInputHeight() * nn_archive.getInputWidth() * 3
+        )
         tile_manager.out.link(interleaved_manip.inputImage)
         nn_input = interleaved_manip.out
 


### PR DESCRIPTION
… crash the pipeline

## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Set MaxutputFrameSize so bigger input size models don't crash the pipeline

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable